### PR TITLE
Check for existing image before build

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # tsops
 
+## 1.4.2
+
+### Patch Changes
+
+- feat: add image existence check before build and force rebuild flag
+
+  - Add `imageExists()` method to DockerClient to check if image already exists in registry using `docker manifest inspect`
+  - Build process now automatically skips building images that already exist in the registry
+  - Add `--force` (`-f`) flag to CLI build command to force rebuild even if image exists
+  - Add `force` option to `build()` method in TsOps API
+  - Improves CI/CD efficiency by avoiding unnecessary rebuilds of existing images
+
+- Updated dependencies []:
+  - @tsops/core@0.5.2
+  - @tsops/node@0.2.3
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsops",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "TypeScript-first toolkit for planning, building, and deploying to Kubernetes",
   "type": "module",
   "bin": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -273,13 +273,18 @@ async function main(): Promise<void> {
     .option('-n, --namespace <name>', 'used to determine dev/prod context')
     .option('-c, --config <path>', 'path to config file', 'tsops.config')
     .option('--dry-run', 'skip external commands, log actions only')
+    .option('-f, --force', 'force rebuild even if image already exists in registry')
     .action(async (options) => {
       const config = await loadConfig(options.config)
       const tsops = createNodeTsOps(config, {
         dryRun: options.dryRun,
         env: new GitEnvironmentProvider(new ProcessEnvironmentProvider())
       })
-      const result = await tsops.build({ namespace: options.namespace, app: options.app })
+      const result = await tsops.build({ 
+        namespace: options.namespace, 
+        app: options.app,
+        force: options.force
+      })
 
       for (const item of result.images) {
         console.log(`- built ${item.app}: ${item.image}`)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @tsops/core
 
+## 0.5.2
+
+### Patch Changes
+
+- feat: add image existence check before build and force rebuild flag
+
+  - Add `imageExists()` method to DockerClient to check if image already exists in registry using `docker manifest inspect`
+  - Build process now automatically skips building images that already exist in the registry
+  - Add `--force` (`-f`) flag to CLI build command to force rebuild even if image exists
+  - Add `force` option to `build()` method in TsOps API
+  - Improves CI/CD efficiency by avoiding unnecessary rebuilds of existing images
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsops/core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Core library for tsops - TypeScript toolkit for Kubernetes",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/src/operations/builder.ts
+++ b/packages/core/src/operations/builder.ts
@@ -26,7 +26,7 @@ export class Builder<
     this.resolver = dependencies.resolver
   }
 
-  async build(options: { app?: string; namespace?: string } = {}): Promise<BuildResult> {
+  async build(options: { app?: string; namespace?: string; force?: boolean } = {}): Promise<BuildResult> {
     // Login to Docker registry before building (reads from env vars)
     await this.docker.login()
 
@@ -49,15 +49,22 @@ export class Builder<
         continue
       }
 
-      // Check if image already exists in registry
-      const exists = await this.docker.imageExists(imageRef)
-      if (exists) {
-        this.logger.info('Image already exists in registry. Skipping build.', {
+      // Check if image already exists in registry (unless force rebuild is requested)
+      if (!options.force) {
+        const exists = await this.docker.imageExists(imageRef)
+        if (exists) {
+          this.logger.info('Image already exists in registry. Skipping build.', {
+            app: appName,
+            image: imageRef
+          })
+          results.push({ app: appName, image: imageRef })
+          continue
+        }
+      } else {
+        this.logger.info('Force rebuild requested. Building image.', {
           app: appName,
           image: imageRef
         })
-        results.push({ app: appName, image: imageRef })
-        continue
       }
 
       // Build context can be extended with namespace variables if needed

--- a/packages/core/src/operations/builder.ts
+++ b/packages/core/src/operations/builder.ts
@@ -49,6 +49,17 @@ export class Builder<
         continue
       }
 
+      // Check if image already exists in registry
+      const exists = await this.docker.imageExists(imageRef)
+      if (exists) {
+        this.logger.info('Image already exists in registry. Skipping build.', {
+          app: appName,
+          image: imageRef
+        })
+        results.push({ app: appName, image: imageRef })
+        continue
+      }
+
       // Build context can be extended with namespace variables if needed
       await this.docker.build(imageRef, build, {})
       if (!this.dryRun) {

--- a/packages/core/src/ports/docker.ts
+++ b/packages/core/src/ports/docker.ts
@@ -8,6 +8,7 @@ export interface DockerLoginOptions {
 
 export interface DockerClient {
   login(options?: DockerLoginOptions): Promise<void>
+  imageExists(imageRef: string): Promise<boolean>
   build(imageRef: string, build: DockerfileBuild, ctx: AppBuildContext): Promise<void>
   push(imageRef: string): Promise<void>
 }

--- a/packages/core/src/tsops.ts
+++ b/packages/core/src/tsops.ts
@@ -176,6 +176,7 @@ export class TsOps<TConfig extends TsOpsConfig<any, any, any, any, any, any, any
    * @param options - Filtering options
    * @param options.app - Target a single app (optional)
    * @param options.namespace - Used to determine dev/prod context (optional)
+   * @param options.force - Force rebuild even if image exists in registry (optional)
    * @returns Build results with app names and image references
    *
    * @example
@@ -184,7 +185,7 @@ export class TsOps<TConfig extends TsOpsConfig<any, any, any, any, any, any, any
    * console.log(result.images[0].image) // => 'ghcr.io/org/api:abc123'
    * ```
    */
-  build(options: { app?: string; namespace?: string } = {}) {
+  build(options: { app?: string; namespace?: string; force?: boolean } = {}) {
     return this.builder.build(options)
   }
 

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @tsops/node
 
+## 0.2.3
+
+### Patch Changes
+
+- feat: add image existence check before build and force rebuild flag
+
+  - Add `imageExists()` method to DockerClient to check if image already exists in registry using `docker manifest inspect`
+  - Build process now automatically skips building images that already exist in the registry
+  - Add `--force` (`-f`) flag to CLI build command to force rebuild even if image exists
+  - Add `force` option to `build()` method in TsOps API
+  - Improves CI/CD efficiency by avoiding unnecessary rebuilds of existing images
+
+- Updated dependencies []:
+  - @tsops/core@0.5.2
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsops/node",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Node-specific adapters and helpers for tsops",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Add a check to skip image builds if the image already exists in the artifact registry.

---
<a href="https://cursor.com/background-agent?bcId=bc-68118066-318a-48c1-be1c-1b5697054ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68118066-318a-48c1-be1c-1b5697054ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

