### PR TITLE
feat(core): defineDockerfileBuild factory for sharing build defaults

### DIFF
--- a/.changeset/define-dockerfile-build.md
+++ b/.changeset/define-dockerfile-build.md
@@ -1,0 +1,6 @@
+---
+'@tsops/core': minor
+'tsops': minor
+---
+
+Add `defineDockerfileBuild(defaults)` helper: a factory that removes the boilerplate of repeating `context` / `platform` / `env` / `args` across every app's `build` block. Each app only supplies its Dockerfile path (and optional per-app overrides, which shallow-merge into the defaults).

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
-export type { TsOpsConfigWithRuntime } from '@tsops/core/config'
-export { defineConfig } from '@tsops/core/config'
+export type { DockerfileBuildDefaults, TsOpsConfigWithRuntime } from '@tsops/core/config'
+export { defineConfig, defineDockerfileBuild } from '@tsops/core/config'
 export type { NormalizedPort, PlanEntry, PlanResult } from '@tsops/core'
 export {
   createConfigResolver,

--- a/packages/core/src/config/build.ts
+++ b/packages/core/src/config/build.ts
@@ -1,0 +1,62 @@
+import type { AppBuildContext, DockerfileBuild } from '../types.js'
+
+/**
+ * Fields that sensibly carry default values across many apps in the same repo.
+ * `dockerfile` is intentionally excluded — each app names its own Dockerfile.
+ */
+export interface DockerfileBuildDefaults {
+  context?: string
+  platform?: string | ((ctx: AppBuildContext) => string)
+  env?: Record<string, string>
+  args?: Record<string, string>
+  target?: string
+}
+
+/**
+ * Create a reusable factory for dockerfile builds. Call it with a Dockerfile
+ * path (and optional per-app overrides) to get a complete `DockerfileBuild`.
+ *
+ * @example
+ * const dockerfile = defineDockerfileBuild({
+ *   context: '.',
+ *   platform: 'linux/amd64',
+ *   env: { TURBO_TELEMETRY_DISABLED: '1' }
+ * })
+ *
+ * apps: {
+ *   api: { build: dockerfile('infra/images/api.dockerfile') },
+ *   web: { build: dockerfile('infra/images/web.dockerfile', { target: 'production' }) }
+ * }
+ */
+export function defineDockerfileBuild(defaults: DockerfileBuildDefaults = {}) {
+  return function dockerfile(
+    path: string,
+    overrides: DockerfileBuildDefaults = {}
+  ): DockerfileBuild {
+    const mergedEnv = mergeRecord(defaults.env, overrides.env)
+    const mergedArgs = mergeRecord(defaults.args, overrides.args)
+    const platform = overrides.platform ?? defaults.platform
+    const target = overrides.target ?? defaults.target
+
+    const result: DockerfileBuild = {
+      type: 'dockerfile',
+      context: overrides.context ?? defaults.context ?? '.',
+      dockerfile: path
+    }
+
+    if (platform !== undefined) result.platform = platform
+    if (target !== undefined) result.target = target
+    if (mergedEnv) result.env = mergedEnv
+    if (mergedArgs) result.args = mergedArgs
+
+    return result
+  }
+}
+
+function mergeRecord(
+  a: Record<string, string> | undefined,
+  b: Record<string, string> | undefined
+): Record<string, string> | undefined {
+  if (!a && !b) return undefined
+  return { ...(a ?? {}), ...(b ?? {}) }
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,2 +1,4 @@
+export type { DockerfileBuildDefaults } from './build.js'
+export { defineDockerfileBuild } from './build.js'
 export type { TsOpsConfigWithRuntime } from './definer.js'
 export { defineConfig } from './definer.js'

--- a/tests/dockerfile-build.test.ts
+++ b/tests/dockerfile-build.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { defineDockerfileBuild } from 'tsops'
+
+describe('defineDockerfileBuild', () => {
+  it('produces a full DockerfileBuild for a given path', () => {
+    const dockerfile = defineDockerfileBuild({
+      context: '.',
+      platform: 'linux/amd64',
+      env: { TURBO_TELEMETRY_DISABLED: '1' }
+    })
+
+    expect(dockerfile('infra/images/api.dockerfile')).toEqual({
+      type: 'dockerfile',
+      context: '.',
+      dockerfile: 'infra/images/api.dockerfile',
+      platform: 'linux/amd64',
+      env: { TURBO_TELEMETRY_DISABLED: '1' }
+    })
+  })
+
+  it('allows per-app overrides', () => {
+    const dockerfile = defineDockerfileBuild({ context: '.', platform: 'linux/amd64' })
+    const build = dockerfile('Dockerfile', { target: 'production', platform: 'linux/arm64' })
+    expect(build).toMatchObject({ target: 'production', platform: 'linux/arm64', context: '.' })
+  })
+
+  it('shallow-merges env and args across defaults and overrides', () => {
+    const dockerfile = defineDockerfileBuild({
+      env: { A: '1', B: '2' },
+      args: { NODE_VERSION: '20' }
+    })
+    const build = dockerfile('Dockerfile', {
+      env: { B: 'override', C: '3' },
+      args: { EXTRA: 'yes' }
+    })
+    expect(build.env).toEqual({ A: '1', B: 'override', C: '3' })
+    expect(build.args).toEqual({ NODE_VERSION: '20', EXTRA: 'yes' })
+  })
+
+  it('defaults context to "." when neither defaults nor overrides set it', () => {
+    const dockerfile = defineDockerfileBuild()
+    expect(dockerfile('Dockerfile').context).toBe('.')
+  })
+
+  it('omits optional fields when unused', () => {
+    const dockerfile = defineDockerfileBuild()
+    const build = dockerfile('Dockerfile')
+    expect(build).not.toHaveProperty('platform')
+    expect(build).not.toHaveProperty('env')
+    expect(build).not.toHaveProperty('args')
+    expect(build).not.toHaveProperty('target')
+  })
+})


### PR DESCRIPTION
## Summary

Continuation (originally PR #30).

\`defineDockerfileBuild({...})\` returns a factory: each app just names its Dockerfile, and \`context\`/\`platform\`/\`env\`/\`args\`/\`target\` come from the shared defaults (with shallow-merge overrides on \`env\`/\`args\`).

No review comments from Copilot on the original PR. All 35 tests pass on rebased HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)