### PR TITLE
fix(ci): pass NPM_TOKEN to changesets/action for npm auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
           setupGitUser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow was failing to publish packages with 404 errors ([run 24911585485](https://github.com/Pom4H/tsops/actions/runs/24911585485/job/72954225177)) because `changesets/action@v1` couldn't authenticate to npm.

The action explicitly checks for `NPM_TOKEN` in its environment before configuring npm auth. The workflow was passing the secret as `NODE_AUTH_TOKEN` (intended for `setup-node`), so the action logged:

> No NPM_TOKEN or OIDC available - assuming npm is already authenticated

…and then ran `pnpm changeset publish` without auth, causing every PUT to npm to 404.

This rename makes `changesets/action` pick up the token and write its own `.npmrc` before publishing.

## Test plan

- [ ] Next push to `main` that creates a release PR / publishes packages succeeds
- [ ] Verify `tsops`, `@tsops/core`, `@tsops/k8`, `@tsops/node` reach `1.9.0` on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)