### PR TITLE
fix(ci): set NODE_AUTH_TOKEN for npm publish and bump action versions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,23 +20,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.17.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: pnpm install
@@ -45,7 +45,7 @@ jobs:
         run: pnpm docs:build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -59,5 +59,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -38,3 +38,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix 404 errors on npm publish by setting `NODE_AUTH_TOKEN` in the `changesets/action` step.
- Bump all GitHub Actions to current major versions.

## Why the 404

`actions/setup-node` with `registry-url` writes an `.npmrc` to `/home/runner/work/_temp/.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and sets `NPM_CONFIG_USERCONFIG` to that path. `changesets/action` separately writes `~/.npmrc` using `NPM_TOKEN`, but pnpm reads the file referenced by `NPM_CONFIG_USERCONFIG`, which expands to the placeholder `XXXXX-XXXXX-XXXXX-XXXXX` because `NODE_AUTH_TOKEN` was never set. npm then returns 404 (it hides 401 on publish to avoid leaking package existence). Passing `NPM_TOKEN` through as `NODE_AUTH_TOKEN` makes the setup-node `.npmrc` resolve correctly.

## Action bumps

- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `pnpm/action-setup` v4 → v5
- `actions/configure-pages` v4 → v6
- `actions/upload-pages-artifact` v3 → v5
- `actions/deploy-pages` v4 → v5
- `changesets/action` stays at v1 (still the current major)

## Test plan

- [ ] Merge to `main` and confirm the Release workflow publishes `tsops`, `@tsops/core`, `@tsops/k8`, `@tsops/node` at 1.9.0 without 404.
- [ ] Confirm the Deploy Docs workflow still builds and deploys to GitHub Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)