### PR TITLE
feat(ci): publish via npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -37,5 +38,3 @@ jobs:
           setupGitUser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,6 +60,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/k8/package.json
+++ b/packages/k8/package.json
@@ -38,6 +38,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -41,6 +41,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
## Summary

Switch the release workflow from `NPM_TOKEN` auth to **GitHub OIDC trusted publishing**. Keeps account-level 2FA fully enforced for human actions while letting CI publish without storing a long-lived npm token.

## Changes

- `.github/workflows/release.yml` — add `id-token: write` permission, drop `NPM_TOKEN` / `NODE_AUTH_TOKEN` env vars.
- `publishConfig.provenance: true` on all four published packages (`tsops`, `@tsops/core`, `@tsops/k8`, `@tsops/node`) so npm attaches a signed build attestation badge.

## Required npm-side setup (before merging!)

On npmjs.com, for **each** of the 4 packages → package settings → **Trusted Publisher** → Add GitHub Actions publisher with:

- Organization / user: `Pom4H`
- Repository: `tsops`
- Workflow filename: `release.yml`
- Environment: *(empty)*

If Trusted Publisher isn't configured on all 4 packages before merge, the release workflow will fail with "no trusted publisher configured".

## Test plan

- [ ] Configure Trusted Publisher on npm for all 4 packages.
- [ ] Merge; confirm the Release workflow publishes 1.9.0 without errors and provenance badges appear on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)