### PR TITLE
feat(core): overlay namespace types + resolver (1/4)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,15 +5,19 @@ export type {
   DependencyError,
   DependencyGraph,
   NormalizedPort,
+  OverlayNamespaceDefinition,
+  OverlayVars,
   PlanEntry,
   PlanResult,
   SensitiveEnvConfig,
-  SensitiveEnvFinding
+  SensitiveEnvFinding,
+  StaticNamespaceDefinition
 } from '@tsops/core'
 export {
   buildGraph,
   createConfigResolver,
   enforceMode,
+  isOverlayNamespace,
   normalizePort,
   normalizePorts,
   pickPort,

--- a/packages/core/src/config/namespaces.ts
+++ b/packages/core/src/config/namespaces.ts
@@ -7,10 +7,13 @@ import type {
   DNSType,
   ExtractNamespaceVarsFromConfig,
   NamespaceRuntime,
+  OverlayNamespaceDefinition,
+  OverlayVars,
   ResourceKind,
   SecretRef,
   TsOpsConfig
 } from '../types.js'
+import { isOverlayNamespace } from '../types.js'
 import type { ProjectResolver } from './project.js'
 
 const CLUSTER_DOMAIN = 'cluster.local'
@@ -22,10 +25,41 @@ export interface CreateHostContextOptions {
   cluster?: ClusterMetadata
   externalHosts?: Record<string, string>
   appsConfig?: any
+  /** Runtime vars supplied to overlay namespaces via `tsops up --var`. */
+  vars?: OverlayVars
+}
+
+/**
+ * A namespace materialised for a single deploy. For static namespaces this is
+ * just the config key. For overlays it carries the resolved name plus the
+ * source key so the deployer can find the overlay config and run hooks.
+ */
+export interface ResolvedNamespace {
+  /** Concrete kubernetes namespace name (after applying overlay `naming`). */
+  name: string
+  /** Original config key — same as `name` for static namespaces. */
+  source: string
+  /** True when this namespace was produced from an overlay template. */
+  overlay: boolean
+  /** Base namespace this overlay inherits from (only set when `overlay`). */
+  base?: string
+  /** Fallback namespace for apps not in --include (only set when `overlay`). */
+  fallback?: string
+  /** External domain (resolved through overlay `domain` template if any). */
+  domain?: string
+  /** Overlay definition that produced this namespace, when applicable. */
+  definition?: OverlayNamespaceDefinition
+  /** Runtime vars used to materialise this overlay. */
+  vars?: OverlayVars
 }
 
 export interface NamespaceResolver<TConfig extends TsOpsConfig<any, any, any, any, any, any, any>> {
-  select(target?: string): string[]
+  select(target?: string, vars?: OverlayVars): string[]
+  /**
+   * Resolve a namespace key (static or overlay) into a concrete `ResolvedNamespace`.
+   * Throws if `target` is an overlay and required vars are missing.
+   */
+  resolve(target: string, vars?: OverlayVars): ResolvedNamespace
   createHostContext(
     namespace: string,
     options?: CreateHostContextOptions
@@ -46,7 +80,7 @@ export function createNamespaceResolver<
   _project: ProjectResolver<TConfig>,
   envProvider: EnvironmentProvider
 ): NamespaceResolver<TConfig> {
-  function select(target?: string): string[] {
+  function select(target?: string, _vars?: OverlayVars): string[] {
     if (target) {
       if (!config.namespaces[target as keyof TConfig['namespaces']]) {
         throw new Error(`Unknown namespace: ${target}`)
@@ -54,7 +88,84 @@ export function createNamespaceResolver<
       return [target]
     }
 
-    return Object.keys(config.namespaces)
+    // Default deploy skips overlay templates — they only materialise when
+    // explicitly targeted with vars (e.g. `tsops up preview --var pr=123`).
+    return Object.entries(config.namespaces)
+      .filter(([, def]) => !isOverlayNamespace(def as any))
+      .map(([key]) => key)
+  }
+
+  function resolve(target: string, vars?: OverlayVars): ResolvedNamespace {
+    const definition = config.namespaces[target as keyof TConfig['namespaces']] as
+      | OverlayNamespaceDefinition
+      | { domain?: string }
+      | undefined
+    if (!definition) throw new Error(`Unknown namespace: ${target}`)
+
+    if (!isOverlayNamespace(definition as any)) {
+      return {
+        name: target,
+        source: target,
+        overlay: false,
+        domain:
+          typeof (definition as { domain?: unknown }).domain === 'string'
+            ? (definition as { domain: string }).domain
+            : undefined
+      }
+    }
+
+    const overlay = definition as OverlayNamespaceDefinition
+    if (!vars) {
+      throw new Error(
+        `Overlay namespace "${target}" requires runtime vars. ` +
+          `Pass them via the CLI (e.g. \`tsops up ${target} --var pr=123\`) or programmatically.`
+      )
+    }
+    const name = overlay.naming(vars)
+    if (!name || typeof name !== 'string') {
+      throw new Error(
+        `Overlay namespace "${target}" produced an invalid name from naming(${JSON.stringify(vars)}).`
+      )
+    }
+    if (!isValidDnsLabel(name)) {
+      throw new Error(
+        `Overlay namespace "${target}" produced "${name}", which is not a valid DNS-1123 label.`
+      )
+    }
+    const base = overlay.extends
+    const baseDef = config.namespaces[base as keyof TConfig['namespaces']]
+    if (!baseDef) {
+      throw new Error(`Overlay namespace "${target}" extends unknown base namespace "${base}".`)
+    }
+    if (isOverlayNamespace(baseDef as any)) {
+      throw new Error(
+        `Overlay namespace "${target}" extends "${base}", which is itself an overlay. ` +
+          `Overlays must extend a static namespace (single hop).`
+      )
+    }
+    const fallback = overlay.fallback
+    const fallbackDef = config.namespaces[fallback as keyof TConfig['namespaces']]
+    if (!fallbackDef) {
+      throw new Error(
+        `Overlay namespace "${target}" declares unknown fallback namespace "${fallback}".`
+      )
+    }
+    if (isOverlayNamespace(fallbackDef as any)) {
+      throw new Error(
+        `Overlay namespace "${target}" falls back to "${fallback}", which is itself an overlay. ` +
+          `Fallback must be a static namespace.`
+      )
+    }
+    return {
+      name,
+      source: target,
+      overlay: true,
+      base,
+      fallback,
+      domain: overlay.domain(vars),
+      definition: overlay,
+      vars
+    }
   }
 
   function createHostContext(
@@ -68,8 +179,45 @@ export function createNamespaceResolver<
     TConfig['configMaps'],
     TConfig['apps']
   > {
-    const metadata = config.namespaces[namespace as keyof TConfig['namespaces']]
-    if (!metadata) throw new Error(`Unknown namespace: ${namespace}`)
+    const rawDefinition = config.namespaces[namespace as keyof TConfig['namespaces']] as
+      | OverlayNamespaceDefinition
+      | Record<string, unknown>
+      | undefined
+    if (!rawDefinition) throw new Error(`Unknown namespace: ${namespace}`)
+
+    let resolvedNamespaceName = namespace
+    let metadata: Record<string, unknown>
+
+    if (isOverlayNamespace(rawDefinition as any)) {
+      // Route through resolve() so DNS-1123, extends-is-static, and
+      // fallback-is-static checks all run consistently.
+      const resolvedNs = resolve(namespace, options.vars)
+      resolvedNamespaceName = resolvedNs.name
+      const overlay = rawDefinition as OverlayNamespaceDefinition
+      const baseMetadata = config.namespaces[overlay.extends as keyof TConfig['namespaces']]
+      const {
+        extends: _e,
+        naming: _n,
+        domain: _d,
+        fallback: _f,
+        cert: _c,
+        database: _db,
+        ...rest
+      } = overlay as Record<string, unknown> & OverlayNamespaceDefinition
+      const overlayVars = (options.vars ?? {}) as OverlayVars
+      // Reserved context keys must always come from tsops, not from user
+      // `--vars`. We strip them from the overlay-vars layer so a stray
+      // `--var namespace=foo` can't silently override `ctx.namespace`.
+      const safeVars = stripReservedKeys(overlayVars)
+      metadata = {
+        ...(baseMetadata as Record<string, unknown>),
+        ...rest,
+        domain: resolvedNs.domain ?? '',
+        ...safeVars
+      }
+    } else {
+      metadata = rawDefinition as Record<string, unknown>
+    }
 
     const projectName = config.project
     const {
@@ -120,7 +268,7 @@ export function createNamespaceResolver<
       if (type === 'ingress') return externalHosts[app] || app
       if (runtime === 'local') return 'localhost'
       if (type === 'cluster' && runtime === 'kubernetes') {
-        return `${app}.${namespace}.svc.${CLUSTER_DOMAIN}`
+        return `${app}.${resolvedNamespaceName}.svc.${CLUSTER_DOMAIN}`
       }
       return app
     }
@@ -192,11 +340,16 @@ export function createNamespaceResolver<
       return str.replace(/\{(\w+)\}/g, (_, key) => vars[key] || '')
     }
 
-    // Create context with helpers and spread namespace variables
+    // Spread namespace variables first so the built-in helpers and metadata
+    // below always win, even if the metadata happens to contain colliding
+    // keys (e.g. an overlay var named `namespace` or a base namespace that
+    // declares its own `dns` field).
     return {
+      ...metadata,
+
       // Metadata
       project: projectName,
-      namespace,
+      namespace: resolvedNamespaceName,
       appName,
       cluster,
 
@@ -215,10 +368,7 @@ export function createNamespaceResolver<
 
       // Utilities
       env,
-      template,
-
-      // ✨ Spread all namespace variables into context
-      ...metadata
+      template
     } as AppHostContextWithHelpers<
       ExtractNamespaceVarsFromConfig<TConfig>,
       TConfig['project'],
@@ -230,8 +380,43 @@ export function createNamespaceResolver<
 
   return {
     select,
+    resolve,
     createHostContext
   }
+}
+
+const DNS_1123_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/
+
+const RESERVED_CONTEXT_KEYS = new Set([
+  'project',
+  'namespace',
+  'appName',
+  'cluster',
+  'dns',
+  'url',
+  'label',
+  'resource',
+  'servicePort',
+  'targetPort',
+  'listenPort',
+  'secret',
+  'configMap',
+  'env',
+  'template',
+  'local',
+  'runtime'
+])
+
+function stripReservedKeys(input: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(input)) {
+    if (!RESERVED_CONTEXT_KEYS.has(k)) out[k] = v
+  }
+  return out
+}
+
+function isValidDnsLabel(name: string): boolean {
+  return name.length <= 63 && DNS_1123_LABEL.test(name)
 }
 
 function resolveRuntime(

--- a/packages/core/src/config/namespaces.ts
+++ b/packages/core/src/config/namespaces.ts
@@ -156,13 +156,21 @@ export function createNamespaceResolver<
           `Fallback must be a static namespace.`
       )
     }
+    const domain = overlay.domain(vars)
+    if (typeof domain !== 'string' || domain.length === 0) {
+      throw new Error(
+        `Overlay namespace "${target}" produced an invalid domain ` +
+          `(${typeof domain === 'string' ? '""' : typeof domain}) from domain(${JSON.stringify(vars)}). ` +
+          `domain() must return a non-empty string.`
+      )
+    }
     return {
       name,
       source: target,
       overlay: true,
       base,
       fallback,
-      domain: overlay.domain(vars),
+      domain,
       definition: overlay,
       vars
     }
@@ -207,13 +215,16 @@ export function createNamespaceResolver<
       const overlayVars = (options.vars ?? {}) as OverlayVars
       // Reserved context keys must always come from tsops, not from user
       // `--vars`. We strip them from the overlay-vars layer so a stray
-      // `--var namespace=foo` can't silently override `ctx.namespace`.
+      // `--var namespace=foo` (or `--var domain=evil`) can't silently
+      // override `ctx.namespace` or the resolved overlay domain.
       const safeVars = stripReservedKeys(overlayVars)
       metadata = {
         ...(baseMetadata as Record<string, unknown>),
         ...rest,
-        domain: resolvedNs.domain ?? '',
-        ...safeVars
+        ...safeVars,
+        // Resolved overlay fields must win over both base metadata and
+        // overlay vars — they're computed by tsops and validated above.
+        domain: resolvedNs.domain ?? ''
       }
     } else {
       metadata = rawDefinition as Record<string, unknown>
@@ -404,7 +415,11 @@ const RESERVED_CONTEXT_KEYS = new Set([
   'env',
   'template',
   'local',
-  'runtime'
+  'runtime',
+  // `domain` is computed by the overlay's domain() template and must not
+  // be shadowed by a `--var domain=...`. Stripping it here, in addition to
+  // the explicit re-assignment after the spread, is belt-and-braces.
+  'domain'
 ])
 
 function stripReservedKeys(input: Record<string, string>): Record<string, string> {

--- a/packages/core/src/operations/planner.ts
+++ b/packages/core/src/operations/planner.ts
@@ -1,17 +1,17 @@
 import type { ConfigResolver } from '../config/resolver.js'
 import {
   buildGraph,
+  type DependencyGraph,
   topoSort,
-  validateDependencies,
-  type DependencyGraph
+  validateDependencies
 } from '../dependencies/graph.js'
 import { normalizePorts } from '../network/ports.js'
-import type { DockerfileBuild, ServicePort, TsOpsConfig } from '../types.js'
+import type { DockerfileBuild, OverlayVars, ServicePort, TsOpsConfig } from '../types.js'
 import {
   enforceMode,
+  type SensitiveEnvFinding,
   scanBuildEnv,
-  scanRuntimeEnv,
-  type SensitiveEnvFinding
+  scanRuntimeEnv
 } from '../validation/sensitive-env.js'
 import type { PlanEntry, PlanResult } from './types.js'
 
@@ -55,13 +55,18 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
   /**
    * Creates a deployment plan based on the configuration and filters.
    *
-   * @param options - Filtering options
-   * @param options.namespace - Target a single namespace (optional)
-   * @param options.app - Target a single app (optional)
-   * @returns Deployment plan with resolved entries
+   * @param options.vars Runtime variables used to materialise overlay
+   *   namespaces (`tsops up <ns> --var key=value`). Required when targeting
+   *   an overlay; ignored for static namespaces.
    */
-  async plan(options: { namespace?: string; app?: string } = {}): Promise<PlanResult> {
-    const namespaces = this.resolver.namespaces.select(options.namespace)
+  async plan(
+    options: {
+      namespace?: string
+      app?: string
+      vars?: OverlayVars
+    } = {}
+  ): Promise<PlanResult> {
+    const namespaces = this.resolver.namespaces.select(options.namespace, options.vars)
     const apps = this.resolver.apps.select(options.app)
     const allAppsForDeps = this.resolver.apps.select()
     const knownAppNames = new Set(allAppsForDeps.map(([name]) => name))
@@ -73,25 +78,30 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
     const dependencies: Record<string, { graph: DependencyGraph; order: string[] }> = {}
     let hasAnyDeps = false
 
-    for (const namespace of namespaces) {
+    for (const namespaceKey of namespaces) {
+      const resolvedNs = this.resolver.namespaces.resolve(namespaceKey, options.vars)
+      const namespace = resolvedNs.name
+      // For `app.deploy` filters and dependency tracking, overlays should
+      // behave as if they were their base — users write `deploy: ['ru-stage']`,
+      // not the runtime overlay name (e.g. `pr-123`).
+      const filterNs = resolvedNs.base ?? namespaceKey
       const namespaceStart = entries.length
       const namespaceApps: Array<{ name: string; needs: readonly string[] }> = []
 
-      // Dependency validation must reason about the full set of apps that
-      // deploy to this namespace — not just the subset selected by
-      // `options.app`. Otherwise `plan({ app: 'api' })` would misreport a
-      // valid dependency on a sibling app as `not-deployed-here`.
       const fullNsApps = allAppsForDeps
-        .filter(([, a]) => this.resolver.apps.shouldDeploy(a, namespace))
+        .filter(([, a]) => this.resolver.apps.shouldDeploy(a, filterNs))
         .map(([name, a]) => ({
           name,
           needs: ((a.needs as readonly string[] | undefined) ?? []) as readonly string[]
         }))
 
       for (const [appName, app] of apps) {
-        if (!this.resolver.apps.shouldDeploy(app, namespace)) continue
+        if (!this.resolver.apps.shouldDeploy(app, filterNs)) continue
 
-        const context = this.resolver.namespaces.createHostContext(namespace, { appName })
+        const context = this.resolver.namespaces.createHostContext(namespaceKey, {
+          appName,
+          vars: options.vars
+        })
         const resolvedEnv = this.resolver.apps.resolveEnv(app, namespace, context)
         const secrets = this.resolver.apps.resolveSecrets(app, namespace, context)
         const configMaps = this.resolver.apps.resolveConfigMaps(app, namespace, context)
@@ -99,10 +109,13 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
         const image = app.image || this.resolver.images.buildRef(appName)
         const { network, host } = this.resolver.apps.resolveNetwork(appName, app, context)
 
-        // Resolve dynamic parameters (can be static values or functions)
-        const resolveParam = <T>(param: T | ((ctx: typeof context) => T) | undefined): T | undefined => {
+        const resolveParam = <T>(
+          param: T | ((ctx: typeof context) => T) | undefined
+        ): T | undefined => {
           if (param === undefined) return undefined
-          return typeof param === 'function' ? (param as (ctx: typeof context) => T)(context) : param
+          return typeof param === 'function'
+            ? (param as (ctx: typeof context) => T)(context)
+            : param
         }
 
         const resolvePorts = (
@@ -136,11 +149,21 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
           secrets,
           configMaps,
           network,
-          podAnnotations: resolveParam(app.podAnnotations as Parameters<typeof resolveParam>[0]) as Record<string, string> | undefined,
-          volumes: resolveParam(app.volumes as Parameters<typeof resolveParam>[0]) as PlanEntry['volumes'],
-          volumeMounts: resolveParam(app.volumeMounts as Parameters<typeof resolveParam>[0]) as PlanEntry['volumeMounts'],
-          args: resolveParam(app.args as Parameters<typeof resolveParam>[0]) as string[] | undefined,
-          ports: resolvePorts(app.ports as ServicePort[] | ((ctx: typeof context) => ServicePort[]) | undefined)
+          podAnnotations: resolveParam(app.podAnnotations as Parameters<typeof resolveParam>[0]) as
+            | Record<string, string>
+            | undefined,
+          volumes: resolveParam(
+            app.volumes as Parameters<typeof resolveParam>[0]
+          ) as PlanEntry['volumes'],
+          volumeMounts: resolveParam(
+            app.volumeMounts as Parameters<typeof resolveParam>[0]
+          ) as PlanEntry['volumeMounts'],
+          args: resolveParam(app.args as Parameters<typeof resolveParam>[0]) as
+            | string[]
+            | undefined,
+          ports: resolvePorts(
+            app.ports as ServicePort[] | ((ctx: typeof context) => ServicePort[]) | undefined
+          )
         }
         entries.push(entry)
 
@@ -150,11 +173,7 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
           if (!scannedBuilds.has(appName)) {
             scannedBuilds.add(appName)
             findings.push(
-              ...scanBuildEnv(
-                appName,
-                app.build as DockerfileBuild | undefined,
-                sensitiveEnvConfig
-              )
+              ...scanBuildEnv(appName, app.build as DockerfileBuild | undefined, sensitiveEnvConfig)
             )
           }
         }
@@ -165,27 +184,16 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
       const deployedInNs = new Set(fullNsApps.map((a) => a.name))
       const hasNsDeps = fullNsApps.some((a) => a.needs.length > 0)
       if (hasNsDeps) {
-        const errors = validateDependencies(
-          fullNsApps,
-          knownAppNames,
-          deployedInNs,
-          namespace
-        )
+        const errors = validateDependencies(fullNsApps, knownAppNames, deployedInNs, namespace)
         if (errors.length > 0) {
           const summary = errors.map((e) => `  - ${e.message}`).join('\n')
-          throw new Error(
-            `Invalid app dependencies in namespace "${namespace}":\n${summary}`
-          )
+          throw new Error(`Invalid app dependencies in namespace "${namespace}":\n${summary}`)
         }
 
-        // Topo-sort the full graph, then reorder only the entries that made
-        // it into this plan, preserving their relative dependency order.
         const fullOrder = topoSort(fullNsApps)
         const selectedSet = new Set(namespaceApps.map((a) => a.name))
         const order = fullOrder.filter((n) => selectedSet.has(n))
-        const entriesByApp = new Map(
-          entries.slice(namespaceStart).map((e) => [e.app, e])
-        )
+        const entriesByApp = new Map(entries.slice(namespaceStart).map((e) => [e.app, e]))
         for (let i = 0; i < order.length; i++) {
           entries[namespaceStart + i] = entriesByApp.get(order[i])!
         }

--- a/packages/core/src/runtime-config.ts
+++ b/packages/core/src/runtime-config.ts
@@ -7,6 +7,7 @@ import type {
   NamespaceRuntime,
   TsOpsConfig
 } from './types.js'
+import { isOverlayNamespace } from './types.js'
 
 const DEFAULT_HTTP_PORT = 80
 const DEFAULT_HTTPS_PORT = 443
@@ -23,6 +24,20 @@ const CLUSTER_DOMAIN = 'cluster.local'
 export function createRuntimeHelpers<
   TConfig extends TsOpsConfig<any, any, any, any, any, any, any>
 >(config: TConfig, namespace: Extract<keyof TConfig['namespaces'], string>) {
+  const rawNamespace = config.namespaces[namespace]
+  if (isOverlayNamespace(rawNamespace as never)) {
+    // Runtime helpers are intended for app code reading
+    // `process.env.TSOPS_NAMESPACE` (which is the resolved overlay name,
+    // e.g. `pr-123` — already a static-shaped namespace from k8s' POV).
+    // Calling this with the overlay *template* key (e.g. `preview`) would
+    // require runtime vars that the helper has no way to obtain, so fail
+    // fast with a clear message instead of throwing somewhere deeper.
+    throw new Error(
+      `createRuntimeHelpers() does not support overlay template namespaces. ` +
+        `"${namespace}" is an overlay; pass the resolved namespace name (e.g. ` +
+        `process.env.TSOPS_NAMESPACE inside a deployed pod) instead.`
+    )
+  }
   const resolver = createConfigResolver(config)
   const namespaceVars = config.namespaces[
     namespace

--- a/packages/core/src/tsops.ts
+++ b/packages/core/src/tsops.ts
@@ -7,7 +7,7 @@ import { Deployer } from './operations/deployer.js'
 import { Planner } from './operations/planner.js'
 import type { DockerClient } from './ports/docker.js'
 import type { KubectlClient } from './ports/kubectl.js'
-import type { TsOpsConfig } from './types.js'
+import type { OverlayVars, TsOpsConfig } from './types.js'
 
 /**
  * Options for configuring TsOps behavior.
@@ -120,7 +120,18 @@ export class TsOps<TConfig extends TsOpsConfig<any, any, any, any, any, any, any
    * console.log(plan.entries[0].image) // => 'ghcr.io/org/api:abc123'
    * ```
    */
-  plan(options: { namespace?: string; app?: string } = {}) {
+  plan(
+    options: {
+      namespace?: string
+      app?: string
+      /**
+       * Runtime variables for overlay namespaces (e.g.
+       * `{ pr: '123' }` for `tsops up preview --var pr=123`). Required
+       * when `namespace` targets an overlay.
+       */
+      vars?: OverlayVars
+    } = {}
+  ) {
     return this.planner.plan(options)
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -32,20 +32,83 @@ export type TagStrategy =
 export type NamespaceRuntime = 'kubernetes' | 'docker' | 'local'
 
 /**
- * Namespace definition - can contain any custom variables.
- * All namespaces in config must have the same shape (consistent structure).
+ * Static namespace definition — declares a long-lived namespace and any
+ * custom variables apps need (region, replicas, base domain, ...).
+ *
+ * Static namespaces are siblings of `OverlayNamespaceDefinition` in the
+ * `NamespaceDefinition` union. Apps see the same shape from both: helpers
+ * (`dns`, `url`, ...) plus whatever you put in this object. For overlays the
+ * extra fields are inherited from the base static namespace and then merged
+ * with the runtime `--vars` at deploy time.
+ *
+ * Within a single config, all *static* namespaces should share the same key
+ * shape so app code can safely destructure the context. Overlays
+ * intentionally diverge (they add `extends` / `naming` / `domain` / ...).
  *
  * @property runtime - Runtime environment for this namespace. Defaults to
  *                     `kubernetes`. `local: true` is a shorthand for
  *                     `runtime: 'local'` kept for backward compatibility.
  */
-export type NamespaceDefinition = {
+export type StaticNamespaceDefinition = {
   /**
    * @deprecated Use `runtime: 'local'` instead. Kept for backward compatibility.
    */
   local?: boolean
   runtime?: NamespaceRuntime
 } & Record<string, unknown>
+
+/**
+ * Runtime variables passed to overlay namespaces via `tsops up --var key=value`.
+ * Always a flat string→string map by the time templates see them.
+ */
+export type OverlayVars = Record<string, string>
+
+/**
+ * Overlay namespace — a namespace template that inherits from a base static
+ * namespace and is materialised at runtime from `--var` values supplied to
+ * `tsops up`. Used for ephemeral PR preview environments.
+ *
+ * Subsequent layers add optional TLS and database lifecycle fields; this
+ * foundation only defines naming / domain / fallback so the resolver can
+ * materialise overlays into concrete namespaces.
+ */
+export type OverlayNamespaceDefinition<
+  TBase extends string = string,
+  TVars extends OverlayVars = OverlayVars
+> = {
+  /** Base namespace this overlay inherits metadata from. */
+  extends: TBase
+  /** Namespace name template. Must produce a DNS-1123 label. */
+  naming: (vars: TVars) => string
+  /** External domain template for the overlay. */
+  domain: (vars: TVars) => string
+  /** Namespace ExternalName Services point at when an app isn't in --include. */
+  fallback: TBase
+  runtime?: NamespaceRuntime
+} & Record<string, unknown>
+
+/**
+ * Namespace definition — either a fully-resolved static namespace or a runtime
+ * overlay template. Most existing configs only use the static form.
+ */
+export type NamespaceDefinition = StaticNamespaceDefinition | OverlayNamespaceDefinition
+
+/**
+ * Type guard: true when the namespace is an overlay template that needs
+ * runtime `--vars` to materialise.
+ */
+export function isOverlayNamespace(
+  ns: NamespaceDefinition | undefined
+): ns is OverlayNamespaceDefinition {
+  return Boolean(
+    ns &&
+      typeof ns === 'object' &&
+      typeof (ns as { extends?: unknown }).extends === 'string' &&
+      typeof (ns as { naming?: unknown }).naming === 'function' &&
+      typeof (ns as { domain?: unknown }).domain === 'function' &&
+      typeof (ns as { fallback?: unknown }).fallback === 'string'
+  )
+}
 
 /**
  * Reserved context keys that cannot be used as namespace variables.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -960,11 +960,34 @@ export type ConfigMapsMap<
 }
 
 /**
- * Extract the shape of namespace variables (all namespaces must have consistent shape).
- * Returns the type of the first namespace's value.
+ * Compile-time discriminator for overlay templates. We can't use the
+ * runtime `isOverlayNamespace` here, so we pattern-match on the overlay's
+ * structural fields. Anything that has both `extends: string` and a
+ * `naming: (...) => any` is an overlay template.
  */
-export type ExtractNamespaceVars<TNamespaces extends Record<string, NamespaceDefinition>> = 
-  TNamespaces[keyof TNamespaces]
+type IsOverlayDefinition<T> = T extends {
+  extends: string
+  naming: (...args: never[]) => unknown
+}
+  ? true
+  : false
+
+/**
+ * Shape of variables apps see in their config-time context.
+ *
+ * Overlay templates are excluded: their fields (`extends`, `naming`,
+ * `domain: (vars) => string`, ...) are template metadata, not user-visible
+ * vars. App code reads the *resolved* overlay context, which is the base
+ * static namespace's vars + the runtime `--vars` — i.e. the same shape as
+ * the static namespace it extends. Including overlays in the union would
+ * regress `domain: string` to `domain: string | ((vars) => string)` for
+ * any config that adds an overlay.
+ */
+export type ExtractNamespaceVars<TNamespaces extends Record<string, NamespaceDefinition>> = {
+  [K in keyof TNamespaces]: IsOverlayDefinition<TNamespaces[K]> extends true
+    ? never
+    : TNamespaces[K]
+}[keyof TNamespaces]
 
 /**
  * Extract namespace variables type from TsOpsConfig

--- a/tests/overlay-namespaces.test.ts
+++ b/tests/overlay-namespaces.test.ts
@@ -1,0 +1,188 @@
+import { createConfigResolver, defineConfig, isOverlayNamespace, Planner } from 'tsops'
+import { describe, expect, it } from 'vitest'
+
+const baseConfig = {
+  project: 'demo',
+  namespaces: {
+    'ru-stage': { domain: 'stage.example.com', secretName: 'stage' },
+    preview: {
+      extends: 'ru-stage' as const,
+      naming: ({ pr }: { pr: string }) => `pr-${pr}`,
+      domain: ({ pr }: { pr: string }) => `pr-${pr}.stage.example.com`,
+      fallback: 'ru-stage' as const
+    }
+  },
+  clusters: {
+    stage: {
+      apiServer: 'https://stage:6443',
+      context: 'stage',
+      namespaces: ['ru-stage', 'preview'] as const
+    }
+  },
+  images: { registry: 'ghcr.io/acme', tagStrategy: 'git-tag' as const }
+}
+
+function makeCfg() {
+  return defineConfig({
+    ...baseConfig,
+    apps: {
+      api: {
+        env: ({ namespace, domain }) => ({
+          NS: namespace as string,
+          DOMAIN: domain as string
+        }),
+        ingress: ({ domain }) => ({ domain: `api.${domain as string}` }),
+        ports: [{ name: 'http', port: 80, targetPort: 3000 }]
+      },
+      web: {
+        ingress: ({ domain }) => ({ domain: `web.${domain as string}` }),
+        ports: [{ name: 'http', port: 80, targetPort: 3000 }]
+      }
+    }
+  })
+}
+
+describe('overlay namespaces (resolver)', () => {
+  it('isOverlayNamespace identifies overlays vs static namespaces', () => {
+    const cfg = makeCfg()
+    expect(isOverlayNamespace(cfg.namespaces['ru-stage'] as any)).toBe(false)
+    expect(isOverlayNamespace(cfg.namespaces.preview as any)).toBe(true)
+  })
+
+  it('select() omits overlays from the default deploy', () => {
+    const cfg = makeCfg()
+    const resolver = createConfigResolver(cfg)
+    expect(resolver.namespaces.select()).toEqual(['ru-stage'])
+  })
+
+  it('resolve() materialises overlay name and domain from runtime vars', () => {
+    const cfg = makeCfg()
+    const resolver = createConfigResolver(cfg)
+    const r = resolver.namespaces.resolve('preview', { pr: '123' })
+    expect(r.overlay).toBe(true)
+    expect(r.name).toBe('pr-123')
+    expect(r.domain).toBe('pr-123.stage.example.com')
+    expect(r.base).toBe('ru-stage')
+    expect(r.fallback).toBe('ru-stage')
+  })
+
+  it('resolve() throws when overlay vars are missing', () => {
+    const cfg = makeCfg()
+    const resolver = createConfigResolver(cfg)
+    expect(() => resolver.namespaces.resolve('preview')).toThrow(/requires runtime vars/)
+  })
+
+  it('resolve() rejects names that are not valid DNS-1123 labels', () => {
+    const cfg = defineConfig({
+      ...baseConfig,
+      namespaces: {
+        ...baseConfig.namespaces,
+        bad: {
+          extends: 'ru-stage' as const,
+          naming: () => 'NOT_VALID',
+          domain: () => 'x.example.com',
+          fallback: 'ru-stage' as const
+        }
+      },
+      apps: { api: { ports: [{ name: 'http', port: 80, targetPort: 3000 }] } }
+    } as any)
+    const resolver = createConfigResolver(cfg)
+    expect(() => resolver.namespaces.resolve('bad', { pr: '1' })).toThrow(/DNS-1123/)
+  })
+
+  it('resolve() rejects extends pointing at another overlay', () => {
+    const cfg = defineConfig({
+      ...baseConfig,
+      namespaces: {
+        ...baseConfig.namespaces,
+        nested: {
+          extends: 'preview' as const,
+          naming: ({ pr }: { pr: string }) => `nested-${pr}`,
+          domain: ({ pr }: { pr: string }) => `nested-${pr}.stage.example.com`,
+          fallback: 'ru-stage' as const
+        }
+      },
+      apps: { api: { ports: [{ name: 'http', port: 80, targetPort: 3000 }] } }
+    } as any)
+    const resolver = createConfigResolver(cfg)
+    expect(() => resolver.namespaces.resolve('nested', { pr: '1' })).toThrow(
+      /extends "preview", which is itself an overlay/
+    )
+  })
+
+  it('resolve() rejects fallback pointing at another overlay', () => {
+    const cfg = defineConfig({
+      ...baseConfig,
+      namespaces: {
+        ...baseConfig.namespaces,
+        bad: {
+          extends: 'ru-stage' as const,
+          naming: ({ pr }: { pr: string }) => `bad-${pr}`,
+          domain: () => 'x.example.com',
+          fallback: 'preview' as const
+        }
+      },
+      apps: { api: { ports: [{ name: 'http', port: 80, targetPort: 3000 }] } }
+    } as any)
+    const resolver = createConfigResolver(cfg)
+    expect(() => resolver.namespaces.resolve('bad', { pr: '1' })).toThrow(
+      /Fallback must be a static namespace/
+    )
+  })
+
+  it('resolve() rejects fallback pointing at unknown namespace', () => {
+    const cfg = defineConfig({
+      ...baseConfig,
+      namespaces: {
+        ...baseConfig.namespaces,
+        bad: {
+          extends: 'ru-stage' as const,
+          naming: ({ pr }: { pr: string }) => `bad-${pr}`,
+          domain: () => 'x.example.com',
+          fallback: 'does-not-exist' as const
+        }
+      },
+      apps: { api: { ports: [{ name: 'http', port: 80, targetPort: 3000 }] } }
+    } as any)
+    const resolver = createConfigResolver(cfg)
+    expect(() => resolver.namespaces.resolve('bad', { pr: '1' })).toThrow(
+      /unknown fallback namespace "does-not-exist"/
+    )
+  })
+
+  it('plan() with overlay vars produces entries under the resolved namespace', async () => {
+    const cfg = makeCfg()
+    const resolver = createConfigResolver(cfg)
+    const planner = new Planner({ resolver })
+    const plan = await planner.plan({ namespace: 'preview', vars: { pr: '42' } })
+    expect(plan.entries.length).toBeGreaterThan(0)
+    for (const entry of plan.entries) {
+      expect(entry.namespace).toBe('pr-42')
+    }
+    const apiEntry = plan.entries.find((e) => e.app === 'api')!
+    expect(apiEntry.env.NS).toBe('pr-42')
+    expect(apiEntry.env.DOMAIN).toBe('pr-42.stage.example.com')
+  })
+
+  it('createHostContext spreads overlay vars into the app context', () => {
+    const cfg = makeCfg()
+    const resolver = createConfigResolver(cfg)
+    const ctx = resolver.namespaces.createHostContext('preview', {
+      vars: { pr: '99', branch: 'feature-x' }
+    }) as { pr?: string; branch?: string; namespace: string; domain?: string }
+    expect(ctx.namespace).toBe('pr-99')
+    expect(ctx.pr).toBe('99')
+    expect(ctx.branch).toBe('feature-x')
+    expect(ctx.domain).toBe('pr-99.stage.example.com')
+  })
+
+  it('createHostContext does not let --vars override reserved keys', () => {
+    const cfg = makeCfg()
+    const resolver = createConfigResolver(cfg)
+    const ctx = resolver.namespaces.createHostContext('preview', {
+      vars: { pr: '5', namespace: 'evil', project: 'evil' }
+    }) as { namespace: string; project: string }
+    expect(ctx.namespace).toBe('pr-5')
+    expect(ctx.project).toBe('demo')
+  })
+})

--- a/tests/overlay-namespaces.test.ts
+++ b/tests/overlay-namespaces.test.ts
@@ -185,4 +185,34 @@ describe('overlay namespaces (resolver)', () => {
     expect(ctx.namespace).toBe('pr-5')
     expect(ctx.project).toBe('demo')
   })
+
+  it('createHostContext: --var domain=... cannot override the resolved overlay domain', () => {
+    const cfg = makeCfg()
+    const resolver = createConfigResolver(cfg)
+    const ctx = resolver.namespaces.createHostContext('preview', {
+      vars: { pr: '8', domain: 'evil.example.com' }
+    }) as { domain: string }
+    expect(ctx.domain).toBe('pr-8.stage.example.com')
+  })
+
+  it('resolve() rejects non-string return from domain()', () => {
+    const cfg = defineConfig({
+      ...baseConfig,
+      namespaces: {
+        ...baseConfig.namespaces,
+        bad: {
+          extends: 'ru-stage' as const,
+          naming: ({ pr }: { pr: string }) => `bad-${pr}`,
+          // intentionally returns non-string
+          domain: () => 42 as unknown as string,
+          fallback: 'ru-stage' as const
+        }
+      },
+      apps: { api: { ports: [{ name: 'http', port: 80, targetPort: 3000 }] } }
+    } as any)
+    const resolver = createConfigResolver(cfg)
+    expect(() => resolver.namespaces.resolve('bad', { pr: '1' })).toThrow(
+      /produced an invalid domain/
+    )
+  })
 })


### PR DESCRIPTION
**Layer 1 of 4** for preview / overlay namespaces (RFC 0001). Stack:

1. **This PR** — types + resolver
2. ExternalName fallback for `--include`
3. `tsops up` / `tsops down` CLI + `kubectl.waitForJob`
4. Cert + database lifecycle hooks

Replaces #43 (the monolithic version). Backup of the original combined branch is preserved at `backup/preview-namespaces-monolith` for reference.

## Summary

Foundation for ephemeral PR-preview environments. Adds the type model and resolver so apps can target a runtime-materialised namespace (e.g. `pr-123`) that inherits from a long-lived static base namespace (`ru-stage`).

```ts
namespaces: {
  'ru-stage': { domain: 'stage.example.com' },
  preview: {
    extends: 'ru-stage',
    naming: ({ pr }) => `pr-${pr}`,
    domain: ({ pr }) => `pr-${pr}.stage.example.com`,
    fallback: 'ru-stage'
  }
}
```

## What lands here

- `OverlayNamespaceDefinition` (`extends` / `naming` / `domain` / `fallback`) is a sibling of the existing static form in `NamespaceDefinition`. The type guard `isOverlayNamespace()` discriminates the union. No cert / database fields yet — those land in layer 4.
- `select(target?, vars?)` skips overlays from the default deploy.
- New `resolve(target, vars?)` materialises an overlay into a concrete namespace, validates DNS-1123, and rejects:
  - missing runtime vars
  - `extends` pointing at another overlay (must be static, single hop)
  - `fallback` pointing at an unknown or overlay namespace
- `createHostContext()` reuses `resolve()` for overlays so identical validation runs everywhere. Built-in context fields (`namespace`, `project`, helpers) always win over `--vars`, so a stray `--var namespace=evil` can't override them.
- `Planner.plan({ vars })` and `TsOps.plan({ vars })` thread the vars through to the resolver.
- `tsops` CLI package re-exports the new types and `isOverlayNamespace`.

## Test plan

- [x] 11 new resolver tests (isOverlayNamespace, select(), resolve(), DNS-1123 validation, extends-overlay rejection, fallback-overlay rejection, unknown fallback, plan with vars, host context vars spreading, reserved-key precedence)
- [x] 64 tests total, full build clean
- [x] Existing static-namespace configs unaffected (no behavioral change for users who don't use overlays)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAwjHxmCFD6RtU9pYJ4NG1)_