### PR TITLE
feat(core,k8): ExternalName fallback for overlay --include (2/4)

### DIFF
--- a/packages/core/src/operations/deployer.ts
+++ b/packages/core/src/operations/deployer.ts
@@ -1,9 +1,14 @@
 import type { ManifestBuilder } from '@tsops/k8'
-import { buildConfigMap, buildNamespace, buildSecret } from '@tsops/k8'
+import {
+  buildConfigMap,
+  buildExternalNameService,
+  buildNamespace,
+  buildSecret
+} from '@tsops/k8'
 import type { ConfigResolver } from '../config/resolver.js'
 import type { Logger } from '../logger.js'
 import type { KubectlClient, SupportedManifest } from '../ports/kubectl.js'
-import type { TsOpsConfig } from '../types.js'
+import type { OverlayVars, TsOpsConfig } from '../types.js'
 import type { Planner } from './planner.js'
 import type {
   AppResourceChanges,
@@ -48,7 +53,14 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
    * All manifests within each group are applied atomically using kubectl batch apply.
    * If any manifest fails, the entire group fails and no changes are made.
    */
-  async deploy(options: { namespace?: string; app?: string } = {}): Promise<DeployResult> {
+  async deploy(
+    options: {
+      namespace?: string
+      app?: string
+      vars?: OverlayVars
+      include?: readonly string[]
+    } = {}
+  ): Promise<DeployResult> {
     const plan = await this.planner.plan(options)
     const entries: DeployResult['entries'] = []
     const createdNamespaces = new Set<string>()
@@ -73,6 +85,55 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
         }
 
         createdNamespaces.add(entry.namespace)
+      }
+
+      // 1b. Apps not in --include become ExternalName proxies into fallback.
+      // We still emit the ingress (and certificate) manifests so the overlay
+      // domain stays routable for the proxied app — only the Deployment and
+      // Secrets/ConfigMaps are skipped, since those live in the base
+      // namespace already.
+      if (entry.fallback) {
+        const serviceName = this.resolver.project.serviceName(entry.app)
+        const stub = buildExternalNameService({
+          serviceName,
+          namespace: entry.namespace,
+          fallbackNamespace: entry.fallback.namespace,
+          baseLabels: {
+            'app.kubernetes.io/name': entry.app,
+            'app.kubernetes.io/part-of': this.resolver.project.name,
+            'tsops/app': entry.app,
+            'tsops/managed': 'true'
+          },
+          ports: entry.ports?.map((p) => ({
+            name: p.name,
+            port: p.port,
+            protocol: p.protocol
+          }))
+        })
+        const stubManifests: SupportedManifest[] = [stub]
+
+        const builtForFallback = this.manifestBuilder.build(entry.app, {
+          namespace: entry.namespace,
+          serviceName,
+          image: entry.image,
+          host: entry.host,
+          env: entry.env,
+          envFrom: entry.envFrom,
+          network: entry.network,
+          podAnnotations: entry.podAnnotations,
+          volumes: entry.volumes,
+          volumeMounts: entry.volumeMounts,
+          args: entry.args,
+          ports: entry.ports
+        })
+        if (builtForFallback.ingress) stubManifests.push(builtForFallback.ingress)
+        if (builtForFallback.ingressRoute) stubManifests.push(builtForFallback.ingressRoute)
+        if (builtForFallback.certificate) stubManifests.push(builtForFallback.certificate)
+
+        const refs = await this.kubectl.applyBatch(stubManifests, { namespace: entry.namespace })
+        applied.push(...refs)
+        entries.push({ ...entry, appliedManifests: applied })
+        continue
       }
 
       // 2. Validate and create secrets (atomically)

--- a/packages/core/src/operations/planner.ts
+++ b/packages/core/src/operations/planner.ts
@@ -64,6 +64,8 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
       namespace?: string
       app?: string
       vars?: OverlayVars
+      /** When set, only these apps deploy normally; others fall back via ExternalName. */
+      include?: readonly string[]
     } = {}
   ): Promise<PlanResult> {
     const namespaces = this.resolver.namespaces.select(options.namespace, options.vars)
@@ -71,6 +73,7 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
     const allAppsForDeps = this.resolver.apps.select()
     const knownAppNames = new Set(allAppsForDeps.map(([name]) => name))
     const entries: PlanEntry[] = []
+    const includeSet = options.include ? new Set(options.include) : undefined
 
     const sensitiveEnvConfig = this.config?.validation?.sensitiveEnv
     const findings: SensitiveEnvFinding[] = []
@@ -97,6 +100,8 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
 
       for (const [appName, app] of apps) {
         if (!this.resolver.apps.shouldDeploy(app, filterNs)) continue
+
+        const useFallback = Boolean(resolvedNs.overlay && includeSet && !includeSet.has(appName))
 
         const context = this.resolver.namespaces.createHostContext(namespaceKey, {
           appName,
@@ -163,7 +168,10 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
             | undefined,
           ports: resolvePorts(
             app.ports as ServicePort[] | ((ctx: typeof context) => ServicePort[]) | undefined
-          )
+          ),
+          fallback: useFallback
+            ? { namespace: resolvedNs.fallback ?? resolvedNs.base ?? filterNs }
+            : undefined
         }
         entries.push(entry)
 

--- a/packages/core/src/operations/types.ts
+++ b/packages/core/src/operations/types.ts
@@ -40,6 +40,20 @@ export interface PlanEntry {
     localPort?: number
     protocol?: 'TCP' | 'UDP'
   }>
+  /**
+   * When set, this entry is a stub: instead of a Deployment, the deployer
+   * emits a `Service: ExternalName` in `entry.namespace` (the overlay) that
+   * points at the same app in `fallback.namespace` (the base / static
+   * namespace) via cluster DNS. Optional ingress resources are still emitted
+   * so the app remains reachable on the overlay's domain.
+   *
+   * Produced when an overlay deploys with `--include` and this app isn't in
+   * the include list.
+   */
+  fallback?: {
+    /** Static namespace whose `<svc>.<ns>.svc.cluster.local` we proxy to. */
+    namespace: string
+  }
 }
 
 export interface PlanResult {

--- a/packages/core/src/tsops.ts
+++ b/packages/core/src/tsops.ts
@@ -224,7 +224,20 @@ export class TsOps<TConfig extends TsOpsConfig<any, any, any, any, any, any, any
    * console.log(result.entries[0].appliedManifests) // => ['Deployment/api', 'Service/api', ...]
    * ```
    */
-  deploy(options: { namespace?: string; app?: string } = {}) {
+  deploy(
+    options: {
+      namespace?: string
+      app?: string
+      /** Runtime variables for overlay namespaces (`--var key=value`). */
+      vars?: OverlayVars
+      /**
+       * Apps to deploy fully. Apps not in this list become `Service:
+       * ExternalName` stubs that proxy to the same app in the overlay's
+       * fallback namespace. Only meaningful when targeting an overlay.
+       */
+      include?: readonly string[]
+    } = {}
+  ) {
     return this.deployer.deploy(options)
   }
 }

--- a/packages/k8/src/builders/external-name-service.ts
+++ b/packages/k8/src/builders/external-name-service.ts
@@ -1,0 +1,44 @@
+import type { ServiceManifest } from '../types.js'
+import { createMetadata } from '../utils.js'
+
+/**
+ * Build a `Service: ExternalName` that proxies traffic to the same service in
+ * a fallback namespace via cluster DNS. Used by overlay namespaces (e.g. PR
+ * previews) to transparently route apps that were not in `--include`.
+ */
+export function buildExternalNameService(options: {
+  serviceName: string
+  namespace: string
+  fallbackNamespace: string
+  baseLabels: Record<string, string>
+  ports?: Array<{ name: string; port: number; protocol?: 'TCP' | 'UDP' }>
+  clusterDomain?: string
+}): ServiceManifest {
+  const {
+    serviceName,
+    namespace,
+    fallbackNamespace,
+    baseLabels,
+    ports,
+    clusterDomain = 'cluster.local'
+  } = options
+
+  const metadata = createMetadata(serviceName, namespace, {
+    ...baseLabels,
+    'tsops/fallback': fallbackNamespace
+  })
+
+  return {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata,
+    spec: {
+      type: 'ExternalName',
+      externalName: `${serviceName}.${fallbackNamespace}.svc.${clusterDomain}`,
+      ports:
+        ports && ports.length > 0
+          ? ports.map((p) => ({ name: p.name, port: p.port, protocol: p.protocol ?? 'TCP' }))
+          : undefined
+    }
+  }
+}

--- a/packages/k8/src/index.ts
+++ b/packages/k8/src/index.ts
@@ -1,4 +1,5 @@
 export { buildConfigMap } from './builders/configmap.js'
+export { buildExternalNameService } from './builders/external-name-service.js'
 export { buildNamespace } from './builders/namespace.js'
 export { buildSecret, buildSecretFromStringData } from './builders/secret.js'
 export * from './manifest-builder.js'

--- a/tests/overlay-namespaces.test.ts
+++ b/tests/overlay-namespaces.test.ts
@@ -176,6 +176,21 @@ describe('overlay namespaces (resolver)', () => {
     expect(ctx.domain).toBe('pr-99.stage.example.com')
   })
 
+  it('plan() with --include marks excluded apps as fallback stubs', async () => {
+    const cfg = makeCfg()
+    const resolver = createConfigResolver(cfg)
+    const planner = new Planner({ resolver })
+    const plan = await planner.plan({
+      namespace: 'preview',
+      vars: { pr: '7' },
+      include: ['api']
+    })
+    const apiEntry = plan.entries.find((e) => e.app === 'api')!
+    const webEntry = plan.entries.find((e) => e.app === 'web')!
+    expect(apiEntry.fallback).toBeUndefined()
+    expect(webEntry.fallback).toEqual({ namespace: 'ru-stage' })
+  })
+
   it('createHostContext does not let --vars override reserved keys', () => {
     const cfg = makeCfg()
     const resolver = createConfigResolver(cfg)


### PR DESCRIPTION
**Layer 2 of 4** for preview / overlay namespaces. Stacked on top of #44.

## Summary

Builds on the overlay resolver: when a user deploys an overlay with `--include a,b`, apps NOT in that list become `Service: ExternalName` proxies pointing at the same Service in the overlay's fallback (static base) namespace. The overlay's domain stays fully routable because we still emit the ingress (and certificate) manifests for the proxied apps — only the Deployment / Secrets / ConfigMaps are skipped.

```bash
# Only worken-front gets a fresh deployment in pr-123;
# worken-api becomes an ExternalName -> worken-api.ru-stage.svc.cluster.local
tsops deploy --namespace preview --var pr=123 --include worken-front
```

## What lands here

- New `buildExternalNameService` manifest builder in `@tsops/k8`, exported from the package barrel.
- `PlanEntry.fallback` carries the target namespace so the deployer can recognise stub entries.
- `Planner.plan({ include })` marks excluded apps as fallback stubs. No-op when targeting a static namespace (overlays only).
- `Deployer.deploy({ include })` emits the ExternalName Service plus any ingress / IngressRoute / Certificate produced by the manifest builder, so partial overlays are reachable on their domain.
- `TsOps.deploy({ vars, include })` exposes the new options.

## Test plan

- [x] New test: `plan() with --include marks excluded apps as fallback stubs` verifies that included apps get a real entry and excluded apps get a fallback stub pointing at the right namespace
- [x] 65 tests total, full build clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAwjHxmCFD6RtU9pYJ4NG1)_