### PR TITLE
feat(core): harden preview overlay lifecycle contract

### DIFF
--- a/docs/guide/preview-overlays.md
+++ b/docs/guide/preview-overlays.md
@@ -1,0 +1,164 @@
+# Preview Overlay Contract
+
+This contract is the authoritative shape for PR-style preview namespaces. Older
+issue sketches are examples only; implementation should follow this document and
+the fixture in `examples/preview-namespaces/tsops.config.ts`.
+
+## CLI
+
+```bash
+tsops up preview --var pr=857
+tsops down preview --var pr=857
+tsops down preview --var pr=857 --keep-database
+```
+
+`tsops up` supports `--skip-cert` and `--skip-database` for operator debugging.
+Product orchestration should not use those flags for normal previews.
+
+## Hook Order
+
+For a resolved overlay namespace such as `pr-857`, `tsops up` applies resources
+in this order:
+
+1. Namespace.
+2. `namespacePolicy` resources (`ResourceQuota`, `LimitRange`).
+3. TLS hook (`cert`).
+4. Access hook (`access`).
+5. Database pre-deploy hook (`database.preDeploy`), awaited before app rollout.
+6. App secrets, config maps, workloads, services, and public routes.
+
+`tsops down` runs `database.postDestroy` before deleting the namespace, unless
+`--keep-database` is set.
+
+## TLS
+
+`cert.mode = "wildcard-shared"` copies a Kubernetes TLS Secret into the resolved
+overlay namespace before public routes are applied.
+
+```ts
+cert: {
+  mode: 'wildcard-shared',
+  secretName: 'stage-worken-ru-wildcard-tls',
+  sourceNamespace: 'kube-system',
+  copyToOverlayNamespace: true,
+}
+```
+
+If the source secret is missing, deployment fails with the source namespace and
+secret name in the error message.
+
+## Access
+
+`access.mode = "traefik-basic-auth"` copies a hashed htpasswd-style Secret into
+the overlay namespace, renders a Traefik `Middleware`, and attaches it to every
+public Ingress emitted by tsops.
+
+```ts
+access: {
+  mode: 'traefik-basic-auth',
+  sourceNamespace: 'kube-system',
+  secretName: 'preview-basic-auth',
+  middlewareName: ({ pr }) => `preview-basic-auth-pr-${pr}`,
+  attachTo: 'all-public-routes',
+  failClosed: true,
+}
+```
+
+If `failClosed` is not explicitly `false`, missing or malformed access secrets
+fail the deploy before public routes are created.
+
+## Namespace Policy
+
+Every production preview overlay should include conservative namespace policy:
+
+```ts
+namespacePolicy: {
+  resourceQuota: {
+    pods: 25,
+    secrets: 50,
+    jobs: 20,
+    requestsCpu: '4',
+    requestsMemory: '8Gi',
+    limitsCpu: '8',
+    limitsMemory: '16Gi',
+    persistentVolumeClaims: 0,
+  },
+  limitRange: {
+    defaultRequestCpu: '100m',
+    defaultRequestMemory: '256Mi',
+    defaultLimitCpu: '500m',
+    defaultLimitMemory: '1Gi',
+  },
+}
+```
+
+These values are initial guardrails; adjust them only after real preview cycle
+measurements.
+
+## Database
+
+Database lifecycle credentials and runtime credentials are distinct. The
+lifecycle secret is copied only so hook Jobs in the overlay namespace can read
+it. App pods should use the generated runtime Secret referenced by
+`runtimeSecret`. For `runtimeSecret.mode = "generated-per-overlay"`, tsops
+creates the Secret before the database pre-deploy Job and app rollout. If the
+Secret already exists with the expected schema and runtime role metadata, tsops
+reuses it so redeploys do not rotate the app password.
+
+```ts
+database: {
+  lifecycleUrlSecret: {
+    name: 'stage-db-lifecycle',
+    key: 'DATABASE_URL',
+    sourceNamespace: 'kube-system',
+  },
+  runtimeSecret: {
+    mode: 'generated-per-overlay',
+    name: ({ pr }) => `pr-${pr}-db-app`,
+    key: 'DATABASE_URL',
+  },
+  runtimeRole: ({ pr }) => `worken_pr_${pr}_app`,
+  schema: ({ pr }) => `pr_${pr}`,
+  preDeploy: {
+    mode: 'job',
+    name: ({ pr }) => `preview-db-prepare-pr-${pr}`,
+    image: `ghcr.io/example/preview-db-prepare:${process.env.GITHUB_SHA}`,
+    timeoutSeconds: 600,
+    env: ({ seed }) => ({
+      PREVIEW_SEED_MODE: seed ?? 'demo',
+    }),
+    logs: 'tail-on-failure',
+  },
+  postDestroy: 'drop-schema',
+}
+```
+
+The Job receives `DATABASE_URL` from the lifecycle secret plus:
+
+- `DATABASE_SCHEMA`
+- `TSOPS_OVERLAY_SCHEMA`
+- `DATABASE_RUNTIME_SECRET_NAME`
+- `DATABASE_RUNTIME_SECRET_KEY`
+- `DATABASE_RUNTIME_ROLE`
+- `DATABASE_RUNTIME_URL` from the generated runtime Secret
+- `DATABASE_RUNTIME_PASSWORD` from the generated runtime Secret
+- any values returned from `preDeploy.env(vars)`
+
+`runtimeSecret` also injects `DATABASE_URL` into app plans as a Kubernetes
+SecretRef and sets `DATABASE_SCHEMA` and `DATABASE_RUNTIME_ROLE`. The generated
+Secret contains the configured runtime URL key plus `DATABASE_PASSWORD`,
+`DATABASE_SCHEMA`, and `DATABASE_RUNTIME_ROLE`.
+
+## Runtime Vars
+
+Use `validateVars` for overlay-local policy that must fail closed before any
+cluster changes happen. For example, V1 preview configs can reject real vendor
+integrations even if an operator invokes raw `tsops`:
+
+```ts
+validateVars: ({ integrations }) => {
+  if (integrations === 'real') {
+    throw new Error('real integrations are not enabled for V1 preview overlays')
+  }
+}
+```

--- a/examples/preview-namespaces/tsops.config.ts
+++ b/examples/preview-namespaces/tsops.config.ts
@@ -28,12 +28,45 @@ const config = defineConfig({
       naming: ({ pr }) => `pr-${pr}`,
       domain: ({ pr }) => `pr-${pr}.stage.example.com`,
       fallback: 'ru-stage',
-      // Reuse the wildcard cert from the base namespace. tsops will copy
-      // the named TLS Secret from `ru-stage` into `pr-<N>` at deploy time
-      // so the IngressRoute can reference it like any local Secret.
+      // Reuse the staging wildcard cert. The source lives outside the base
+      // app namespace, so sourceNamespace is explicit and tsops copies the
+      // secret into each preview namespace before public routes are applied.
       cert: {
         mode: 'wildcard-shared',
-        secretName: 'stage-wildcard-tls'
+        secretName: 'stage-worken-ru-wildcard-tls',
+        sourceNamespace: 'kube-system',
+        copyToOverlayNamespace: true
+      },
+      access: {
+        mode: 'traefik-basic-auth',
+        sourceNamespace: 'kube-system',
+        secretName: 'preview-basic-auth',
+        middlewareName: ({ pr }) => `preview-basic-auth-pr-${pr}`,
+        attachTo: 'all-public-routes',
+        failClosed: true
+      },
+      namespacePolicy: {
+        resourceQuota: {
+          pods: 25,
+          secrets: 50,
+          jobs: 20,
+          requestsCpu: '4',
+          requestsMemory: '8Gi',
+          limitsCpu: '8',
+          limitsMemory: '16Gi',
+          persistentVolumeClaims: 0
+        },
+        limitRange: {
+          defaultRequestCpu: '100m',
+          defaultRequestMemory: '256Mi',
+          defaultLimitCpu: '500m',
+          defaultLimitMemory: '1Gi'
+        }
+      },
+      validateVars: ({ integrations }) => {
+        if (integrations === 'real') {
+          throw new Error('real integrations are not enabled for V1 preview overlays')
+        }
       },
       // To issue a fresh cert per overlay instead, point `cert` at any Job
       // that produces a TLS Secret in the overlay namespace. The example
@@ -50,18 +83,34 @@ const config = defineConfig({
       //   }
       // },
       database: {
-        urlSecret: { name: 'stage', key: 'DATABASE_URL' },
+        lifecycleUrlSecret: {
+          name: 'stage-db-lifecycle',
+          key: 'DATABASE_URL',
+          sourceNamespace: 'kube-system'
+        },
+        runtimeSecret: {
+          mode: 'generated-per-overlay',
+          name: ({ pr }) => `pr-${pr}-db-app`,
+          key: 'DATABASE_URL'
+        },
+        runtimeRole: ({ pr }) => `worken_pr_${pr}_app`,
         schema: ({ pr }) => `pr_${pr}`,
-        preDeploy: 'create-schema',
+        preDeploy: {
+          mode: 'job',
+          name: ({ pr }) => `preview-db-prepare-pr-${pr}`,
+          image: `ghcr.io/example/preview-db-prepare:${process.env.GITHUB_SHA ?? 'local'}`,
+          timeoutSeconds: 600,
+          env: ({ seed }) => ({
+            PREVIEW_SEED_MODE: seed ?? 'demo'
+          }),
+          logs: 'tail-on-failure'
+        },
         postDestroy: 'drop-schema',
-        appEnvOverride: (_vars, baseUrl, schema) => ({
-          // When DATABASE_URL is a plain string we rewrite it to scope the
-          // connection to the per-overlay schema. When the app binds it via
-          // SecretRef/ConfigMapRef instead, baseUrl is undefined and tsops
-          // drops the DATABASE_URL key automatically — DATABASE_SCHEMA still
-          // applies, so app code can read it and SET search_path itself.
-          ...(baseUrl ? { DATABASE_URL: `${baseUrl}?schema=${schema}` } : {}),
-          DATABASE_SCHEMA: schema
+        appEnvOverride: (_vars, _baseUrl, schema) => ({
+          // `runtimeSecret` injects DATABASE_URL from a generated per-preview
+          // secret. Keep schema selection explicit for app/runtime adapters.
+          DATABASE_SCHEMA: schema,
+          WORKEN_INTEGRATIONS_MODE: 'mock'
         })
       }
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,14 +1,16 @@
-export type { DockerfileBuildDefaults, TsOpsConfigWithRuntime } from '@tsops/core/config'
-export { defineConfig, defineDockerfileBuild } from '@tsops/core/config'
 export type {
   CustomJobConfig,
   DependencyEdge,
   DependencyError,
   DependencyGraph,
   NormalizedPort,
+  OverlayAccessStrategy,
   OverlayCertStrategy,
   OverlayDatabase,
   OverlayNamespaceDefinition,
+  OverlayNamespacePolicy,
+  OverlaySecretKeyRef,
+  OverlayTemplate,
   OverlayVars,
   PlanEntry,
   PlanResult,
@@ -23,10 +25,12 @@ export {
   isOverlayNamespace,
   normalizePort,
   normalizePorts,
-  pickPort,
   Planner,
+  pickPort,
   scanBuildEnv,
   scanRuntimeEnv,
   topoSort,
   validateDependencies
 } from '@tsops/core'
+export type { DockerfileBuildDefaults, TsOpsConfigWithRuntime } from '@tsops/core/config'
+export { defineConfig, defineDockerfileBuild } from '@tsops/core/config'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@tsops/core",
   "version": "1.9.0",
   "description": "Core library for tsops - TypeScript toolkit for Kubernetes",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/core/src/config/namespaces.ts
+++ b/packages/core/src/config/namespaces.ts
@@ -132,6 +132,7 @@ export function createNamespaceResolver<
         `Overlay namespace "${target}" produced "${name}", which is not a valid DNS-1123 label.`
       )
     }
+    overlay.validateVars?.(vars)
     const base = overlay.extends
     const baseDef = config.namespaces[base as keyof TConfig['namespaces']]
     if (!baseDef) {
@@ -209,7 +210,10 @@ export function createNamespaceResolver<
         domain: _d,
         fallback: _f,
         cert: _c,
+        access: _a,
+        namespacePolicy: _np,
         database: _db,
+        validateVars: _vv,
         ...rest
       } = overlay as Record<string, unknown> & OverlayNamespaceDefinition
       const overlayVars = (options.vars ?? {}) as OverlayVars
@@ -452,7 +456,6 @@ function selectPortForRuntime(
       return selected.localPort ?? selected.containerPort
     case 'docker':
       return selected.containerPort
-    case 'kubernetes':
     default:
       return selected.servicePort
   }

--- a/packages/core/src/operations/cert-hook.ts
+++ b/packages/core/src/operations/cert-hook.ts
@@ -52,15 +52,19 @@ export async function runCertbotHook(
   const { namespace, baseNamespace, cert, kubectl, logger } = options
 
   if (cert.mode === 'wildcard-shared') {
+    if (cert.copyToOverlayNamespace === false) {
+      return undefined
+    }
+    const sourceNamespace = cert.sourceNamespace ?? baseNamespace
     logger.info('Copying shared TLS secret into overlay', {
-      from: baseNamespace,
+      from: sourceNamespace,
       to: namespace,
       secretName: cert.secretName
     })
-    const source = await kubectl.get('Secret', cert.secretName, baseNamespace)
+    const source = await kubectl.get('Secret', cert.secretName, sourceNamespace)
     if (!source) {
       throw new Error(
-        `Cert hook (wildcard-shared): TLS secret "${cert.secretName}" not found in base namespace "${baseNamespace}".`
+        `Cert hook (wildcard-shared): TLS secret "${cert.secretName}" not found in source namespace "${sourceNamespace}".`
       )
     }
     const copy = stripServerFields(source, namespace)

--- a/packages/core/src/operations/db-hook.ts
+++ b/packages/core/src/operations/db-hook.ts
@@ -1,7 +1,13 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomBytes } from 'node:crypto'
+import { buildSecret } from '@tsops/k8'
 import type { Logger } from '../logger.js'
 import type { KubectlClient, SupportedManifest } from '../ports/kubectl.js'
-import type { CustomJobConfig, OverlayDatabase, OverlayVars } from '../types.js'
+import type {
+  CustomJobConfig,
+  OverlayDatabase,
+  OverlaySecretKeyRef,
+  OverlayVars
+} from '../types.js'
 
 interface DbHookCommonOptions {
   namespace: string
@@ -61,6 +67,15 @@ function assertValidSchema(schema: string): void {
   }
 }
 
+function assertValidIdentifier(kind: string, value: string): void {
+  if (!POSTGRES_IDENT.test(value)) {
+    throw new Error(
+      `Invalid PostgreSQL ${kind} "${value}". ` +
+        `${kind} must match ${POSTGRES_IDENT.source} (letters, digits, underscores; 1–63 chars).`
+    )
+  }
+}
+
 /**
  * Pre-deploy database hook for overlay namespaces.
  *
@@ -77,25 +92,52 @@ function assertValidSchema(schema: string): void {
  */
 export async function runDatabasePreDeploy(
   options: DbHookCommonOptions
-): Promise<{ jobName: string }> {
+): Promise<{ jobName: string; timeoutSeconds?: number }> {
   const { namespace, baseNamespace, vars, database, kubectl, logger } = options
   const schema = database.schema(vars)
   assertValidSchema(schema)
   const slug = toK8sName(schema)
+  const lifecycleSecret = getLifecycleUrlSecret(database, vars)
 
   // The Job runs in the overlay namespace and reads `DATABASE_URL` via
   // `secretKeyRef` from a Secret in *that* namespace. The user declares the
   // Secret in the base (static) namespace, so we materialise a copy into the
   // overlay before the Job is applied. Idempotent: re-applying overwrites.
-  await ensureUrlSecretInOverlay({ namespace, baseNamespace, database, kubectl, logger })
+  await ensureUrlSecretInOverlay({
+    namespace,
+    baseNamespace,
+    database,
+    lifecycleSecret,
+    kubectl,
+    logger
+  })
+  await ensureRuntimeSecretInOverlay({
+    namespace,
+    vars,
+    database,
+    lifecycleSecret,
+    schema,
+    kubectl,
+    logger
+  })
 
   if (typeof database.preDeploy === 'object') {
     validateCustomJob(database.preDeploy)
-    const jobName = toK8sName(`tsops-db-custom-${slug}`)
-    const job = renderCustomJob(jobName, namespace, schema, database, database.preDeploy)
+    const jobName = database.preDeploy.name
+      ? toK8sName(resolveTemplate(database.preDeploy.name, vars))
+      : toK8sName(`tsops-db-custom-${slug}`)
+    const job = renderCustomJob(
+      jobName,
+      namespace,
+      schema,
+      lifecycleSecret,
+      database,
+      database.preDeploy,
+      vars
+    )
     logger.info('Running custom database pre-deploy job', { namespace, schema, jobName })
     await kubectl.apply(job, { namespace })
-    return { jobName }
+    return { jobName, timeoutSeconds: database.preDeploy.timeoutSeconds }
   }
 
   const jobName = toK8sName(`tsops-db-create-${slug}`)
@@ -104,6 +146,9 @@ export async function runDatabasePreDeploy(
     namespace,
     name: jobName,
     database,
+    lifecycleSecret,
+    vars,
+    schema,
     sqlSteps: [`CREATE SCHEMA IF NOT EXISTS "${schema}"`]
   })
   await kubectl.apply(createJob, { namespace })
@@ -142,17 +187,28 @@ export async function runDatabasePostDestroy(
   assertValidSchema(schema)
   const slug = toK8sName(schema)
   const jobName = toK8sName(`tsops-db-drop-${slug}`)
+  const lifecycleSecret = getLifecycleUrlSecret(database, vars)
 
   // Same reason as in runDatabasePreDeploy: the drop Job needs the connection
   // Secret available locally. If the namespace was created by `up` we'd
   // already have it, but `down` has to be safe to call standalone too.
-  await ensureUrlSecretInOverlay({ namespace, baseNamespace, database, kubectl, logger })
+  await ensureUrlSecretInOverlay({
+    namespace,
+    baseNamespace,
+    database,
+    lifecycleSecret,
+    kubectl,
+    logger
+  })
 
   logger.info('Dropping overlay schema', { namespace, schema, jobName })
   const job = renderPsqlJob({
     namespace,
     name: jobName,
     database,
+    lifecycleSecret,
+    vars,
+    schema,
     sqlSteps: [`DROP SCHEMA IF EXISTS "${schema}" CASCADE`]
   })
   await kubectl.apply(job, { namespace })
@@ -168,60 +224,157 @@ async function ensureUrlSecretInOverlay(input: {
   namespace: string
   baseNamespace: string
   database: OverlayDatabase
+  lifecycleSecret: ResolvedSecretKeyRef
   kubectl: KubectlClient
   logger: Logger
 }): Promise<void> {
-  const { namespace, baseNamespace, database, kubectl, logger } = input
-  if (namespace === baseNamespace) return
-  const source = await kubectl.get('Secret', database.urlSecret.name, baseNamespace)
+  const { namespace, baseNamespace, lifecycleSecret, kubectl, logger } = input
+  const sourceNamespace = lifecycleSecret.sourceNamespace ?? baseNamespace
+  if (namespace === sourceNamespace) return
+  const source = await kubectl.get('Secret', lifecycleSecret.name, sourceNamespace)
   if (!source) {
     throw new Error(
-      `Database hook: Secret "${database.urlSecret.name}" not found in base namespace "${baseNamespace}". ` +
+      `Database hook: Secret "${lifecycleSecret.name}" not found in source namespace "${sourceNamespace}". ` +
         `The overlay's database connection Secret must exist in the base namespace so it can be copied into "${namespace}".`
     )
   }
   const sourceData = (source as unknown as { data?: Record<string, string> }).data ?? {}
-  if (!(database.urlSecret.key in sourceData)) {
+  if (!(lifecycleSecret.key in sourceData)) {
     throw new Error(
-      `Database hook: Secret "${database.urlSecret.name}" in namespace "${baseNamespace}" ` +
-        `does not contain key "${database.urlSecret.key}".`
+      `Database hook: Secret "${lifecycleSecret.name}" in namespace "${sourceNamespace}" ` +
+        `does not contain key "${lifecycleSecret.key}".`
     )
   }
-  const sourceMeta =
-    ((source as unknown as { metadata?: Record<string, unknown> }).metadata ??
-      {}) as Record<string, unknown>
+  const sourceMeta = ((source as unknown as { metadata?: Record<string, unknown> }).metadata ??
+    {}) as Record<string, unknown>
   const labels = (sourceMeta.labels as Record<string, string> | undefined) ?? {}
   const copy = {
     apiVersion: 'v1',
     kind: 'Secret',
     type: (source as unknown as { type?: string }).type ?? 'Opaque',
     metadata: {
-      name: database.urlSecret.name,
+      name: lifecycleSecret.name,
       namespace,
       labels: {
         ...labels,
         'tsops/managed': 'true',
-        'tsops/copied-from': baseNamespace,
+        'tsops/copied-from': sourceNamespace,
         'tsops/hook': 'database'
       }
     },
     data: sourceData
   } as unknown as SupportedManifest
   logger.info('Copying database urlSecret into overlay', {
-    from: baseNamespace,
+    from: sourceNamespace,
     to: namespace,
-    secretName: database.urlSecret.name
+    secretName: lifecycleSecret.name
   })
   await kubectl.apply(copy, { namespace })
+}
+
+async function ensureRuntimeSecretInOverlay(input: {
+  namespace: string
+  vars: OverlayVars
+  database: OverlayDatabase
+  lifecycleSecret: ResolvedSecretKeyRef
+  schema: string
+  kubectl: KubectlClient
+  logger: Logger
+}): Promise<void> {
+  const { namespace, vars, database, lifecycleSecret, schema, kubectl, logger } = input
+  const runtimeSecret = database.runtimeSecret
+  if (runtimeSecret?.mode !== 'generated-per-overlay') return
+  if (!database.runtimeRole) {
+    throw new Error(
+      'Database hook: database.runtimeRole is required when runtimeSecret.mode is "generated-per-overlay".'
+    )
+  }
+
+  const secretName = resolveTemplate(runtimeSecret.name, vars)
+  const runtimeRole = resolveTemplate(database.runtimeRole, vars)
+  assertValidIdentifier('runtime role', runtimeRole)
+
+  const existing = await kubectl.getSecretData(secretName, namespace)
+  if (
+    existing?.[runtimeSecret.key] &&
+    existing.DATABASE_PASSWORD &&
+    existing.DATABASE_SCHEMA === schema &&
+    existing.DATABASE_RUNTIME_ROLE === runtimeRole
+  ) {
+    logger.info('Using existing generated runtime database Secret', {
+      namespace,
+      secretName,
+      schema
+    })
+    return
+  }
+
+  const lifecycleData = await kubectl.getSecretData(lifecycleSecret.name, namespace)
+  const lifecycleUrl = lifecycleData?.[lifecycleSecret.key]
+  if (!lifecycleUrl) {
+    throw new Error(
+      `Database hook: Secret "${lifecycleSecret.name}" in namespace "${namespace}" ` +
+        `does not contain decoded key "${lifecycleSecret.key}" required to generate runtime credentials.`
+    )
+  }
+
+  const password = randomBytes(32).toString('base64url')
+  const runtimeUrl = buildRuntimeDatabaseUrl(lifecycleUrl, runtimeRole, password)
+  const manifest = buildSecret(
+    secretName,
+    namespace,
+    {
+      [runtimeSecret.key]: runtimeUrl,
+      DATABASE_PASSWORD: password,
+      DATABASE_SCHEMA: schema,
+      DATABASE_RUNTIME_ROLE: runtimeRole
+    },
+    {
+      'tsops/managed': 'true',
+      'tsops/hook': 'database',
+      'tsops/secret-purpose': 'preview-runtime-database'
+    }
+  )
+
+  logger.info('Creating generated runtime database Secret', {
+    namespace,
+    secretName,
+    schema,
+    runtimeRole
+  })
+  await kubectl.apply(manifest as unknown as SupportedManifest, { namespace })
+}
+
+function buildRuntimeDatabaseUrl(lifecycleUrl: string, runtimeRole: string, password: string) {
+  let url: URL
+  try {
+    url = new URL(lifecycleUrl)
+  } catch {
+    throw new Error('Database hook: lifecycle DATABASE_URL must be a valid PostgreSQL URL.')
+  }
+
+  if (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') {
+    throw new Error(
+      `Database hook: lifecycle DATABASE_URL must use postgres/postgresql protocol, got "${url.protocol}".`
+    )
+  }
+
+  url.username = runtimeRole
+  url.password = password
+  url.searchParams.delete('schema')
+  return url.toString()
 }
 
 function renderPsqlJob(input: {
   namespace: string
   name: string
   database: OverlayDatabase
+  lifecycleSecret: ResolvedSecretKeyRef
+  vars: OverlayVars
+  schema: string
   sqlSteps: string[]
 }): SupportedManifest {
-  const { namespace, name, database, sqlSteps } = input
+  const { namespace, name, database, lifecycleSecret, vars, schema, sqlSteps } = input
   const sql = sqlSteps.map((s) => s.replace(/"/g, '\\"')).join('; ')
 
   const job = {
@@ -249,11 +402,13 @@ function renderPsqlJob(input: {
                   name: 'DATABASE_URL',
                   valueFrom: {
                     secretKeyRef: {
-                      name: database.urlSecret.name,
-                      key: database.urlSecret.key
+                      name: lifecycleSecret.name,
+                      key: lifecycleSecret.key
                     }
                   }
-                }
+                },
+                ...renderDatabaseMetadataEnv(database, vars, schema),
+                ...renderRuntimeSecretEnv(database, vars)
               ]
             }
           ]
@@ -269,9 +424,14 @@ function renderCustomJob(
   jobName: string,
   namespace: string,
   schema: string,
+  lifecycleSecret: ResolvedSecretKeyRef,
   database: OverlayDatabase,
-  custom: CustomJobConfig
+  custom: CustomJobConfig,
+  vars: OverlayVars
 ): SupportedManifest {
+  const command = custom.command ? resolveTemplate(custom.command, vars) : undefined
+  const args = custom.args ? resolveTemplate(custom.args, vars) : undefined
+  const customEnv = typeof custom.env === 'function' ? custom.env(vars) : (custom.env ?? {})
   const job = {
     apiVersion: 'batch/v1',
     kind: 'Job',
@@ -290,20 +450,22 @@ function renderCustomJob(
             {
               name: 'migrate',
               image: custom.image,
-              command: custom.command,
-              args: custom.args,
+              command,
+              args,
               env: [
                 {
                   name: 'DATABASE_URL',
                   valueFrom: {
                     secretKeyRef: {
-                      name: database.urlSecret.name,
-                      key: database.urlSecret.key
+                      name: lifecycleSecret.name,
+                      key: lifecycleSecret.key
                     }
                   }
                 },
                 { name: 'TSOPS_OVERLAY_SCHEMA', value: schema },
-                ...Object.entries(custom.env ?? {}).map(([k, v]) => ({ name: k, value: v }))
+                ...renderDatabaseMetadataEnv(database, vars, schema),
+                ...renderRuntimeSecretEnv(database, vars),
+                ...Object.entries(customEnv).map(([k, v]) => ({ name: k, value: v }))
               ],
               envFrom: (custom.envFrom ?? []).map((ref) =>
                 ref.secretName
@@ -318,4 +480,96 @@ function renderCustomJob(
   }
 
   return job as unknown as SupportedManifest
+}
+
+interface ResolvedSecretKeyRef {
+  name: string
+  key: string
+  sourceNamespace?: string
+}
+
+function getLifecycleUrlSecret(database: OverlayDatabase, vars: OverlayVars): ResolvedSecretKeyRef {
+  const configured = database.lifecycleUrlSecret ?? database.urlSecret
+  if (!configured) {
+    throw new Error(
+      'Database hook requires database.lifecycleUrlSecret (or legacy database.urlSecret).'
+    )
+  }
+  return {
+    name: resolveTemplate((configured as OverlaySecretKeyRef).name, vars),
+    key: configured.key,
+    sourceNamespace: configured.sourceNamespace
+  }
+}
+
+function resolveTemplate<T>(value: T | ((vars: OverlayVars) => T), vars: OverlayVars): T {
+  return typeof value === 'function' ? (value as (vars: OverlayVars) => T)(vars) : value
+}
+
+function renderDatabaseMetadataEnv(
+  database: OverlayDatabase,
+  vars: OverlayVars,
+  schema: string | undefined
+): Array<{ name: string; value: string }> {
+  const env: Array<{ name: string; value: string }> = []
+  const runtimeSecret = database.runtimeSecret
+  if (runtimeSecret?.mode === 'generated-per-overlay') {
+    env.push(
+      {
+        name: 'DATABASE_RUNTIME_SECRET_NAME',
+        value: resolveTemplate(runtimeSecret.name, vars)
+      },
+      { name: 'DATABASE_RUNTIME_SECRET_KEY', value: runtimeSecret.key }
+    )
+  }
+  if (database.runtimeRole) {
+    env.push({
+      name: 'DATABASE_RUNTIME_ROLE',
+      value: resolveTemplate(database.runtimeRole, vars)
+    })
+  }
+  if (schema) {
+    env.push({ name: 'DATABASE_SCHEMA', value: schema })
+  }
+  return dedupeEnv(env)
+}
+
+function renderRuntimeSecretEnv(
+  database: OverlayDatabase,
+  vars: OverlayVars
+): Array<{ name: string; valueFrom: { secretKeyRef: { name: string; key: string } } }> {
+  const runtimeSecret = database.runtimeSecret
+  if (runtimeSecret?.mode !== 'generated-per-overlay') return []
+  const secretName = resolveTemplate(runtimeSecret.name, vars)
+  return [
+    {
+      name: 'DATABASE_RUNTIME_URL',
+      valueFrom: {
+        secretKeyRef: {
+          name: secretName,
+          key: runtimeSecret.key
+        }
+      }
+    },
+    {
+      name: 'DATABASE_RUNTIME_PASSWORD',
+      valueFrom: {
+        secretKeyRef: {
+          name: secretName,
+          key: 'DATABASE_PASSWORD'
+        }
+      }
+    }
+  ]
+}
+
+function dedupeEnv(
+  env: Array<{ name: string; value: string }>
+): Array<{ name: string; value: string }> {
+  const seen = new Set<string>()
+  return env.filter((item) => {
+    if (seen.has(item.name)) return false
+    seen.add(item.name)
+    return true
+  })
 }

--- a/packages/core/src/operations/deployer.ts
+++ b/packages/core/src/operations/deployer.ts
@@ -1,14 +1,14 @@
 import type { ManifestBuilder } from '@tsops/k8'
-import {
-  buildConfigMap,
-  buildExternalNameService,
-  buildNamespace,
-  buildSecret
-} from '@tsops/k8'
+import { buildConfigMap, buildExternalNameService, buildNamespace, buildSecret } from '@tsops/k8'
 import type { ConfigResolver } from '../config/resolver.js'
 import type { Logger } from '../logger.js'
 import type { KubectlClient, SupportedManifest } from '../ports/kubectl.js'
-import type { OverlayVars, TsOpsConfig } from '../types.js'
+import type {
+  OverlayAccessStrategy,
+  OverlayNamespacePolicy,
+  OverlayVars,
+  TsOpsConfig
+} from '../types.js'
 import { runCertbotHook } from './cert-hook.js'
 import { runDatabasePostDestroy, runDatabasePreDeploy } from './db-hook.js'
 import type { Planner } from './planner.js'
@@ -85,7 +85,7 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
             namespace: entry.namespace
           })
           applied.push(ref)
-        } catch (error) {
+        } catch {
           // Namespace might already exist, that's okay
         }
 
@@ -100,6 +100,18 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
             !overlayHooksRun.has(entry.namespace)
           ) {
             overlayHooksRun.add(entry.namespace)
+            if (resolved.definition?.namespacePolicy) {
+              const policyManifests = renderNamespacePolicy(
+                resolved.name,
+                resolved.definition.namespacePolicy
+              )
+              if (policyManifests.length > 0) {
+                const refs = await this.kubectl.applyBatch(policyManifests, {
+                  namespace: resolved.name
+                })
+                applied.push(...refs)
+              }
+            }
             if (!options.skipCert && resolved.definition?.cert) {
               const certResult = await runCertbotHook({
                 namespace: resolved.name,
@@ -112,6 +124,16 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
                 await this.kubectl.waitForJob(certResult.jobName, resolved.name)
               }
             }
+            if (resolved.definition?.access) {
+              const refs = await runAccessHook({
+                namespace: resolved.name,
+                vars: resolved.vars ?? options.vars,
+                access: resolved.definition.access,
+                kubectl: this.kubectl,
+                logger: this.logger
+              })
+              applied.push(...refs)
+            }
             if (!options.skipDatabase && resolved.definition?.database) {
               const dbResult = await runDatabasePreDeploy({
                 namespace: resolved.name,
@@ -122,7 +144,9 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
                 logger: this.logger
               })
               if (dbResult?.jobName) {
-                await this.kubectl.waitForJob(dbResult.jobName, resolved.name)
+                await this.kubectl.waitForJob(dbResult.jobName, resolved.name, {
+                  timeoutSeconds: dbResult.timeoutSeconds
+                })
               }
             }
           }
@@ -581,7 +605,7 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
         { manifest: appManifests.certificate, kind: 'Certificate' }
       ]
 
-      for (const { manifest, kind } of manifestList) {
+      for (const { manifest } of manifestList) {
         if (!manifest) continue
 
         const change = await this.analyzeManifest(
@@ -728,4 +752,132 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
 
     return change
   }
+}
+
+function renderNamespacePolicy(
+  namespace: string,
+  policy: OverlayNamespacePolicy
+): SupportedManifest[] {
+  const manifests: SupportedManifest[] = []
+  if (policy.resourceQuota) {
+    const hard: Record<string, string> = {}
+    if (policy.resourceQuota.pods !== undefined) hard.pods = String(policy.resourceQuota.pods)
+    if (policy.resourceQuota.secrets !== undefined)
+      hard.secrets = String(policy.resourceQuota.secrets)
+    if (policy.resourceQuota.jobs !== undefined)
+      hard['count/jobs.batch'] = String(policy.resourceQuota.jobs)
+    if (policy.resourceQuota.requestsCpu) hard['requests.cpu'] = policy.resourceQuota.requestsCpu
+    if (policy.resourceQuota.requestsMemory)
+      hard['requests.memory'] = policy.resourceQuota.requestsMemory
+    if (policy.resourceQuota.limitsCpu) hard['limits.cpu'] = policy.resourceQuota.limitsCpu
+    if (policy.resourceQuota.limitsMemory) hard['limits.memory'] = policy.resourceQuota.limitsMemory
+    if (policy.resourceQuota.persistentVolumeClaims !== undefined) {
+      hard.persistentvolumeclaims = String(policy.resourceQuota.persistentVolumeClaims)
+    }
+    manifests.push({
+      apiVersion: 'v1',
+      kind: 'ResourceQuota',
+      metadata: {
+        name: 'tsops-preview-quota',
+        namespace,
+        labels: { 'tsops/managed': 'true', 'tsops/hook': 'namespace-policy' }
+      },
+      spec: { hard }
+    } as unknown as SupportedManifest)
+  }
+
+  if (policy.limitRange) {
+    const defaults: Record<string, string> = {}
+    const defaultRequests: Record<string, string> = {}
+    if (policy.limitRange.defaultLimitCpu) defaults.cpu = policy.limitRange.defaultLimitCpu
+    if (policy.limitRange.defaultLimitMemory) defaults.memory = policy.limitRange.defaultLimitMemory
+    if (policy.limitRange.defaultRequestCpu)
+      defaultRequests.cpu = policy.limitRange.defaultRequestCpu
+    if (policy.limitRange.defaultRequestMemory)
+      defaultRequests.memory = policy.limitRange.defaultRequestMemory
+    manifests.push({
+      apiVersion: 'v1',
+      kind: 'LimitRange',
+      metadata: {
+        name: 'tsops-preview-limits',
+        namespace,
+        labels: { 'tsops/managed': 'true', 'tsops/hook': 'namespace-policy' }
+      },
+      spec: {
+        limits: [
+          {
+            type: 'Container',
+            ...(Object.keys(defaults).length > 0 ? { default: defaults } : {}),
+            ...(Object.keys(defaultRequests).length > 0 ? { defaultRequest: defaultRequests } : {})
+          }
+        ]
+      }
+    } as unknown as SupportedManifest)
+  }
+
+  return manifests
+}
+
+async function runAccessHook(input: {
+  namespace: string
+  vars: OverlayVars
+  access: OverlayAccessStrategy
+  kubectl: KubectlClient
+  logger: Logger
+}): Promise<string[]> {
+  const { namespace, vars, access, kubectl, logger } = input
+  if (access.mode !== 'traefik-basic-auth') return []
+  const middlewareName = resolveTemplate(access.middlewareName, vars)
+  const source = await kubectl.get('Secret', access.secretName, access.sourceNamespace)
+  if (!source) {
+    const message = `Access hook: BasicAuth secret "${access.secretName}" not found in source namespace "${access.sourceNamespace}".`
+    if (access.failClosed !== false) throw new Error(message)
+    logger.warn(message)
+    return []
+  }
+  const sourceData = (source as unknown as { data?: Record<string, string> }).data ?? {}
+  if (!('users' in sourceData) && !('usersFile' in sourceData)) {
+    throw new Error(
+      `Access hook: BasicAuth secret "${access.secretName}" in namespace "${access.sourceNamespace}" must contain "users" or "usersFile".`
+    )
+  }
+  const secretCopy = {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    type: (source as unknown as { type?: string }).type ?? 'Opaque',
+    metadata: {
+      name: access.secretName,
+      namespace,
+      labels: {
+        'tsops/managed': 'true',
+        'tsops/copied-from': access.sourceNamespace,
+        'tsops/hook': 'access'
+      }
+    },
+    data: sourceData
+  } as unknown as SupportedManifest
+  const middleware = {
+    apiVersion: 'traefik.io/v1alpha1',
+    kind: 'Middleware',
+    metadata: {
+      name: middlewareName,
+      namespace,
+      labels: { 'tsops/managed': 'true', 'tsops/hook': 'access' }
+    },
+    spec: {
+      basicAuth: {
+        secret: access.secretName
+      }
+    }
+  } as unknown as SupportedManifest
+  logger.info('Applying preview access middleware', {
+    namespace,
+    secretName: access.secretName,
+    middlewareName
+  })
+  return kubectl.applyBatch([secretCopy, middleware], { namespace })
+}
+
+function resolveTemplate<T>(value: T | ((vars: OverlayVars) => T), vars: OverlayVars): T {
+  return typeof value === 'function' ? (value as (vars: OverlayVars) => T)(vars) : value
 }

--- a/packages/core/src/operations/planner.ts
+++ b/packages/core/src/operations/planner.ts
@@ -174,6 +174,43 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
             : undefined
         }
 
+        if (
+          !useFallback &&
+          resolvedNs.overlay &&
+          resolvedNs.definition?.access &&
+          resolvedNs.vars
+        ) {
+          const access = resolvedNs.definition.access
+          if (access.mode === 'traefik-basic-auth' && entry.network?.ingress) {
+            const middlewareName = resolveTemplate(access.middlewareName, resolvedNs.vars)
+            entry.network.ingress.annotations = {
+              ...(entry.network.ingress.annotations ?? {}),
+              'traefik.ingress.kubernetes.io/router.middlewares': `${namespace}-${middlewareName}@kubernetescrd`
+            }
+          }
+        }
+
+        if (
+          !useFallback &&
+          resolvedNs.overlay &&
+          resolvedNs.definition?.database &&
+          resolvedNs.vars
+        ) {
+          const database = resolvedNs.definition.database
+          const schema = database.schema(resolvedNs.vars)
+          if (database.runtimeSecret?.mode === 'generated-per-overlay') {
+            entry.env.DATABASE_URL = {
+              __type: 'SecretRef',
+              secretName: resolveTemplate(database.runtimeSecret.name, resolvedNs.vars),
+              key: database.runtimeSecret.key
+            }
+          }
+          entry.env.DATABASE_SCHEMA = schema
+          if (database.runtimeRole) {
+            entry.env.DATABASE_RUNTIME_ROLE = resolveTemplate(database.runtimeRole, resolvedNs.vars)
+          }
+        }
+
         // Apply overlay-level env override (e.g. expose DATABASE_SCHEMA so
         // apps can pick up the per-overlay schema). We always invoke the
         // callback when the app actually deploys here, so non-DATABASE_URL
@@ -187,7 +224,7 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
           resolvedNs.definition?.database?.appEnvOverride &&
           resolvedNs.vars
         ) {
-          const baseEnv = entry.env['DATABASE_URL']
+          const baseEnv = entry.env.DATABASE_URL
           const baseUrlIsTyped = baseEnv !== undefined && typeof baseEnv !== 'string'
           const baseUrlString = typeof baseEnv === 'string' ? baseEnv : undefined
           const overrides = resolvedNs.definition.database.appEnvOverride(
@@ -245,7 +282,13 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
         const order = fullOrder.filter((n) => selectedSet.has(n))
         const entriesByApp = new Map(entries.slice(namespaceStart).map((e) => [e.app, e]))
         for (let i = 0; i < order.length; i++) {
-          entries[namespaceStart + i] = entriesByApp.get(order[i])!
+          const orderedEntry = entriesByApp.get(order[i])
+          if (!orderedEntry) {
+            throw new Error(
+              `Could not reorder missing app "${order[i]}" in namespace "${namespace}"`
+            )
+          }
+          entries[namespaceStart + i] = orderedEntry
         }
         dependencies[namespace] = {
           graph: buildGraph(fullNsApps),
@@ -262,4 +305,8 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
       dependencies: hasAnyDeps ? dependencies : undefined
     }
   }
+}
+
+function resolveTemplate<T>(value: T | ((vars: OverlayVars) => T), vars: OverlayVars): T {
+  return typeof value === 'function' ? (value as (vars: OverlayVars) => T)(vars) : value
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -63,17 +63,29 @@ export type StaticNamespaceDefinition = {
  */
 export type OverlayVars = Record<string, string>
 
+export type OverlayTemplate<TVars extends OverlayVars, T> = T | ((vars: TVars) => T)
+
+export interface OverlaySecretKeyRef<TVars extends OverlayVars = OverlayVars> {
+  name: OverlayTemplate<TVars, string>
+  key: string
+  sourceNamespace?: string
+}
+
 /**
  * Custom job configuration for overlay lifecycle hooks (cert issuance,
  * database migrations, ...). Kept generic so tsops doesn't vendor any
  * particular tool (certbot, prisma, golang-migrate, ...).
  */
-export interface CustomJobConfig {
+export interface CustomJobConfig<TVars extends OverlayVars = OverlayVars> {
+  mode?: 'job'
   image: string
-  command?: string[]
-  args?: string[]
-  env?: Record<string, string>
+  name?: OverlayTemplate<TVars, string>
+  command?: OverlayTemplate<TVars, string[]>
+  args?: OverlayTemplate<TVars, string[]>
+  env?: Record<string, string> | ((vars: TVars) => Record<string, string>)
   envFrom?: Array<{ secretName?: string; configMapName?: string }>
+  timeoutSeconds?: number
+  logs?: 'tail-on-failure' | 'none'
 }
 
 /**
@@ -94,6 +106,10 @@ export type OverlayCertStrategy =
       mode: 'wildcard-shared'
       /** Name of the TLS Secret in the base namespace to copy. */
       secretName: string
+      /** Namespace containing the source TLS Secret. Defaults to the overlay base namespace. */
+      sourceNamespace?: string
+      /** Copy into the overlay namespace before public routes are applied. Defaults to true. */
+      copyToOverlayNamespace?: boolean
     }
   | {
       mode: 'job'
@@ -119,7 +135,18 @@ export type OverlayCertStrategy =
  *   leak between PR previews.
  */
 export interface OverlayDatabase<TVars extends OverlayVars = OverlayVars> {
-  urlSecret: { name: string; key: string }
+  /**
+   * Lifecycle/admin database URL used by schema hooks. `urlSecret` is kept for
+   * backward compatibility; new preview configs should use `lifecycleUrlSecret`.
+   */
+  urlSecret?: { name: string; key: string; sourceNamespace?: string }
+  lifecycleUrlSecret?: OverlaySecretKeyRef<TVars>
+  runtimeSecret?: {
+    mode: 'generated-per-overlay'
+    name: OverlayTemplate<TVars, string>
+    key: string
+  }
+  runtimeRole?: OverlayTemplate<TVars, string>
   schema: (vars: TVars) => string
   /**
    * `'create-schema'` runs `CREATE SCHEMA IF NOT EXISTS <s>` and stops.
@@ -128,7 +155,7 @@ export interface OverlayDatabase<TVars extends OverlayVars = OverlayVars> {
    * migrate image (`prisma migrate deploy`, `golang-migrate`, ...). tsops
    * does not bundle a migration runner.
    */
-  preDeploy: 'create-schema' | CustomJobConfig
+  preDeploy: 'create-schema' | CustomJobConfig<TVars>
   postDestroy: 'drop-schema'
   /**
    * Extra env injected into all apps in this overlay. Useful to expose
@@ -145,6 +172,34 @@ export interface OverlayDatabase<TVars extends OverlayVars = OverlayVars> {
     baseUrl: string | undefined,
     schema: string
   ) => Record<string, string>
+}
+
+export type OverlayAccessStrategy<TVars extends OverlayVars = OverlayVars> = {
+  mode: 'traefik-basic-auth'
+  sourceNamespace: string
+  secretName: string
+  middlewareName: OverlayTemplate<TVars, string>
+  attachTo: 'all-public-routes'
+  failClosed?: boolean
+}
+
+export interface OverlayNamespacePolicy {
+  resourceQuota?: {
+    pods?: number
+    secrets?: number
+    jobs?: number
+    requestsCpu?: string
+    requestsMemory?: string
+    limitsCpu?: string
+    limitsMemory?: string
+    persistentVolumeClaims?: number
+  }
+  limitRange?: {
+    defaultRequestCpu?: string
+    defaultRequestMemory?: string
+    defaultLimitCpu?: string
+    defaultLimitMemory?: string
+  }
 }
 
 /**
@@ -169,8 +224,14 @@ export type OverlayNamespaceDefinition<
   fallback: TBase
   /** TLS strategy. Defaults to inheriting the base namespace's ingress TLS. */
   cert?: OverlayCertStrategy
+  /** Optional access gate rendered before public preview routes. */
+  access?: OverlayAccessStrategy<TVars>
+  /** Optional ResourceQuota/LimitRange policy rendered into each overlay namespace. */
+  namespacePolicy?: OverlayNamespacePolicy
   /** Optional schema-per-overlay PostgreSQL lifecycle. */
   database?: OverlayDatabase<TVars>
+  /** Optional runtime var validator for fail-closed overlay-specific policy. */
+  validateVars?: (vars: TVars) => void
   runtime?: NamespaceRuntime
 } & Record<string, unknown>
 
@@ -221,13 +282,11 @@ type ReservedContextKeys =
 /**
  * Validate that namespace variables don't use reserved names
  */
-export type ValidateNamespaceVars<T extends Record<string, unknown>> = Extract<
-  keyof T,
-  ReservedContextKeys
-> extends never
+export type ValidateNamespaceVars<T extends Record<string, unknown>> =
+  Extract<keyof T, ReservedContextKeys> extends never
     ? T
-    : { 
-      __error: 'Namespace variables cannot use reserved context names'
+    : {
+        __error: 'Namespace variables cannot use reserved context names'
         __conflicts: Extract<keyof T, ReservedContextKeys>
       }
 
@@ -267,57 +326,56 @@ export type BuildDefinition = DockerfileBuild | GenericBuild
 /**
  * Extract secret names from secrets map (like DomainKey for domain)
  */
-export type SecretKey<TSecrets> = NonNullable<TSecrets> extends Record<string, unknown>
-  ? Extract<keyof NonNullable<TSecrets>, string>
-  : string
+export type SecretKey<TSecrets> =
+  NonNullable<TSecrets> extends Record<string, unknown>
+    ? Extract<keyof NonNullable<TSecrets>, string>
+    : string
 
 /**
  * Extract configMap names from configMaps map (like DomainKey for domain)
  */
-export type ConfigMapKey<TConfigMaps> = NonNullable<TConfigMaps> extends Record<string, unknown>
-  ? Extract<keyof NonNullable<TConfigMaps>, string>
-  : string
+export type ConfigMapKey<TConfigMaps> =
+  NonNullable<TConfigMaps> extends Record<string, unknown>
+    ? Extract<keyof NonNullable<TConfigMaps>, string>
+    : string
 
 /**
  * Extract app names from apps map
  */
-export type AppKey<TApps> = NonNullable<TApps> extends Record<string, unknown>
-  ? Extract<keyof NonNullable<TApps>, string>
-  : string
+export type AppKey<TApps> =
+  NonNullable<TApps> extends Record<string, unknown>
+    ? Extract<keyof NonNullable<TApps>, string>
+    : string
 
 /**
  * Infer value keys for a given secret name from TSecrets map.
  * Supports both object and function-based secret definitions.
  */
-export type SecretValueKeys<
-  TSecrets,
-  TName extends SecretKey<TSecrets>
-> = NonNullable<TSecrets> extends Record<string, unknown>
-  ? NonNullable<TSecrets>[TName] extends (...args: never[]) => infer R
+export type SecretValueKeys<TSecrets, TName extends SecretKey<TSecrets>> =
+  NonNullable<TSecrets> extends Record<string, unknown>
+    ? NonNullable<TSecrets>[TName] extends (...args: never[]) => infer R
       ? R extends Record<string, string>
         ? Extract<keyof R, string>
         : string
       : NonNullable<TSecrets>[TName] extends Record<string, string>
         ? Extract<keyof NonNullable<TSecrets>[TName], string>
-      : string
-  : string
+        : string
+    : string
 
 /**
  * Infer value keys for a given configMap name from TConfigMaps map.
  * Supports both object and function-based configMap definitions.
  */
-export type ConfigMapValueKeys<
-  TConfigMaps,
-  TName extends ConfigMapKey<TConfigMaps>
-> = NonNullable<TConfigMaps> extends Record<string, unknown>
-  ? NonNullable<TConfigMaps>[TName] extends (...args: never[]) => infer R
+export type ConfigMapValueKeys<TConfigMaps, TName extends ConfigMapKey<TConfigMaps>> =
+  NonNullable<TConfigMaps> extends Record<string, unknown>
+    ? NonNullable<TConfigMaps>[TName] extends (...args: never[]) => infer R
       ? R extends Record<string, string>
         ? Extract<keyof R, string>
         : string
       : NonNullable<TConfigMaps>[TName] extends Record<string, string>
         ? Extract<keyof NonNullable<TConfigMaps>[TName], string>
-      : string
-  : string
+        : string
+    : string
 
 /**
  * Special marker type for secret references in env definitions
@@ -379,24 +437,26 @@ export type EnvValue = string | SecretRef | ConfigMapRef
 /**
  * Extract secret names from app's secrets definition
  */
-export type ExtractSecretNames<T> = T extends Record<string, Record<string, string>>
-  ? Extract<keyof T, string>
-  : T extends (ctx: never) => infer R
-  ? R extends Record<string, Record<string, string>>
-    ? Extract<keyof R, string>
-    : string
-  : string
+export type ExtractSecretNames<T> =
+  T extends Record<string, Record<string, string>>
+    ? Extract<keyof T, string>
+    : T extends (ctx: never) => infer R
+      ? R extends Record<string, Record<string, string>>
+        ? Extract<keyof R, string>
+        : string
+      : string
 
 /**
  * Extract configMap names from app's configMaps definition
  */
-export type ExtractConfigMapNames<T> = T extends Record<string, Record<string, string>>
-  ? Extract<keyof T, string>
-  : T extends (ctx: never) => infer R
-  ? R extends Record<string, Record<string, string>>
-    ? Extract<keyof R, string>
-    : string
-  : string
+export type ExtractConfigMapNames<T> =
+  T extends Record<string, Record<string, string>>
+    ? Extract<keyof T, string>
+    : T extends (ctx: never) => infer R
+      ? R extends Record<string, Record<string, string>>
+        ? Extract<keyof R, string>
+        : string
+      : string
 
 /**
  * Cluster metadata available in context
@@ -471,7 +531,7 @@ export interface AppContextCoreHelpers<
   // ============================================================================
   // METADATA
   // ============================================================================
-  
+
   /** Current project name from config */
   project: TProject
 
@@ -496,13 +556,13 @@ export interface AppContextCoreHelpers<
    * @example
    * // Cluster internal DNS
    * dns('api', 'cluster') // -> 'api.my-namespace.svc.cluster.local'
-   * 
+   *
    * // Service name only
    * dns('api', 'service') // -> 'api'
-   * 
+   *
    * // External DNS (resolved from ingress configuration)
    * dns('api', 'ingress') // -> 'api.example.com' (if ingress configured)
-   * 
+   *
    * // Usage in env:
    * env: ({ dns }) => ({
    *   BACKEND_URL: `https://${dns('backend', 'ingress')}`
@@ -589,7 +649,7 @@ export interface AppContextCoreHelpers<
    * // Reference entire secret (envFrom)
    * env: ({ secret }) => secret('api-secrets')
    * // Generates: envFrom: [{ secretRef: { name: 'api-secrets' } }]
-   * 
+   *
    * // Reference specific key (valueFrom)
    * env: ({ secret }) => ({
    *   JWT_SECRET: secret('api-secrets', 'JWT_SECRET')
@@ -599,7 +659,7 @@ export interface AppContextCoreHelpers<
   secret: {
     (secretName: TSecretNames): SecretRef
     <TName extends SecretKey<TSecrets>>(
-      secretName: TName, 
+      secretName: TName,
       key: SecretValueKeys<TSecrets, TName>
     ): SecretRef
   }
@@ -613,7 +673,7 @@ export interface AppContextCoreHelpers<
    * // Reference entire configMap (envFrom)
    * env: ({ configMap }) => configMap('api-config')
    * // Generates: envFrom: [{ configMapRef: { name: 'api-config' } }]
-   * 
+   *
    * // Reference specific key (valueFrom)
    * env: ({ configMap }) => ({
    *   LOG_LEVEL: configMap('api-config', 'LOG_LEVEL')
@@ -623,7 +683,7 @@ export interface AppContextCoreHelpers<
   configMap: {
     (configMapName: TConfigMapNames): ConfigMapRef
     <TName extends ConfigMapKey<TConfigMaps>>(
-      configMapName: TName, 
+      configMapName: TName,
       key: ConfigMapValueKeys<TConfigMaps, TName>
     ): ConfigMapRef
   }
@@ -681,7 +741,7 @@ export type AppHostContextWithHelpers<
 /**
  * Extended context with helper functions for app configuration.
  * This is what env/secrets/configMaps config functions receive.
- * 
+ *
  * Note: Variables like `dev`, `production`, etc. should be declared in namespace definitions.
  */
 export type AppEnvContext<
@@ -711,14 +771,7 @@ export type AppEnvResolver<
   ctx: AppEnvContext<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>
 ) =>
   | AppEnvSource<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>
-  | readonly AppEnvSource<
-      TNamespaceVars,
-      TProject,
-      TNamespaceName,
-      TSecrets,
-      TConfigMaps,
-      TApps
-    >[]
+  | readonly AppEnvSource<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>[]
 
 /**
  * A single env source: a plain record of env vars, an entire secret / configMap
@@ -748,14 +801,7 @@ export type AppEnv<
   TApps = undefined
 > =
   | AppEnvSource<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>
-  | readonly AppEnvSource<
-      TNamespaceVars,
-      TProject,
-      TNamespaceName,
-      TSecrets,
-      TConfigMaps,
-      TApps
-    >[]
+  | readonly AppEnvSource<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>[]
 
 /**
  * Fully resolved env for one app in one namespace. `envFrom` mirrors the k8s
@@ -932,7 +978,14 @@ export type AppParameter<
 > =
   | T
   | ((
-      ctx: AppHostContextWithHelpers<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>
+      ctx: AppHostContextWithHelpers<
+        TNamespaceVars,
+        TProject,
+        TNamespaceName,
+        TSecrets,
+        TConfigMaps,
+        TApps
+      >
     ) => T)
 
 export type AppDefinition<
@@ -949,23 +1002,62 @@ export type AppDefinition<
   podAnnotations?:
     | Record<string, string>
     | ((
-        ctx: AppHostContextWithHelpers<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>
+        ctx: AppHostContextWithHelpers<
+          TNamespaceVars,
+          TProject,
+          TNamespaceName,
+          TSecrets,
+          TConfigMaps,
+          TApps
+        >
       ) => Record<string, string>)
   volumes?:
     | Volume[]
-    | ((ctx: AppHostContextWithHelpers<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>) => Volume[])
+    | ((
+        ctx: AppHostContextWithHelpers<
+          TNamespaceVars,
+          TProject,
+          TNamespaceName,
+          TSecrets,
+          TConfigMaps,
+          TApps
+        >
+      ) => Volume[])
   volumeMounts?:
     | VolumeMount[]
     | ((
-        ctx: AppHostContextWithHelpers<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>
+        ctx: AppHostContextWithHelpers<
+          TNamespaceVars,
+          TProject,
+          TNamespaceName,
+          TSecrets,
+          TConfigMaps,
+          TApps
+        >
       ) => VolumeMount[])
   args?:
     | string[]
-    | ((ctx: AppHostContextWithHelpers<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>) => string[])
+    | ((
+        ctx: AppHostContextWithHelpers<
+          TNamespaceVars,
+          TProject,
+          TNamespaceName,
+          TSecrets,
+          TConfigMaps,
+          TApps
+        >
+      ) => string[])
   ports?:
     | ServicePort[]
     | ((
-        ctx: AppHostContextWithHelpers<TNamespaceVars, TProject, TNamespaceName, TSecrets, TConfigMaps, TApps>
+        ctx: AppHostContextWithHelpers<
+          TNamespaceVars,
+          TProject,
+          TNamespaceName,
+          TSecrets,
+          TConfigMaps,
+          TApps
+        >
       ) => ServicePort[])
   deploy?: AppDeploySelection<TNamespaceName> | undefined
   /**
@@ -1098,10 +1190,10 @@ export type TsOpsConfig<
    * Namespace definitions with custom variables.
    * All namespaces must have the same shape (consistent structure).
    * Variables defined here are available in app configuration functions.
-   * 
+   *
    * @example
    * namespaces: {
-   *   dev: { 
+   *   dev: {
    *     domain: 'dev.example.com',
    *     replicas: 1,
    *     dbHost: 'dev-db.internal'
@@ -1126,7 +1218,7 @@ export type TsOpsConfig<
       TApps
     >
   }
-  /** 
+  /**
    * Secrets collection organized by secret name.
    * @example
    * secrets: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
 
   tests:
     dependencies:
+      '@tsops/core':
+        specifier: workspace:*
+        version: link:../packages/core
       tsops:
         specifier: workspace:*
         version: link:../packages/cli

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -1,0 +1,475 @@
+import {
+  createConfigResolver,
+  type KubectlClient,
+  type SupportedManifest,
+  TsOps
+} from '@tsops/core'
+import { defineConfig } from 'tsops'
+import { describe, expect, it } from 'vitest'
+
+const noopLogger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {}
+}
+
+const noopDocker = {
+  async login() {},
+  async imageExists() {
+    return false
+  },
+  async build() {},
+  async push() {}
+}
+
+class FakeKubectl implements KubectlClient {
+  applied: Array<{ manifest: SupportedManifest; namespace: string }> = []
+  deleted: Array<{ kind: string; name: string; namespace: string }> = []
+  getCalls: Array<{ kind: string; name: string; namespace: string }> = []
+  waited: Array<{ name: string; namespace: string; timeoutSeconds?: number }> = []
+  private readonly objects = new Map<string, SupportedManifest>()
+
+  seed(manifest: SupportedManifest) {
+    this.objects.set(
+      keyFor(
+        manifest.kind ?? '',
+        manifest.metadata?.name ?? '',
+        manifest.metadata?.namespace ?? ''
+      ),
+      manifest
+    )
+  }
+
+  async apply(manifest: SupportedManifest, options: { namespace: string }) {
+    this.applied.push({ manifest, namespace: options.namespace })
+    this.seed(manifest)
+    return `${manifest.kind}/${manifest.metadata?.name}`
+  }
+
+  async applyBatch(manifests: SupportedManifest[], options: { namespace: string }) {
+    const refs: string[] = []
+    for (const manifest of manifests) {
+      refs.push(await this.apply(manifest, options))
+    }
+    return refs
+  }
+
+  async secretExists(secretName: string, namespace: string) {
+    return this.objects.has(keyFor('Secret', secretName, namespace))
+  }
+
+  async getSecretData(secretName: string, namespace: string) {
+    const secret = this.objects.get(keyFor('Secret', secretName, namespace)) as
+      | (SupportedManifest & { data?: Record<string, string>; stringData?: Record<string, string> })
+      | undefined
+    if (!secret) return null
+    if (secret.stringData) return secret.stringData
+    if (!secret.data) return null
+    return Object.fromEntries(
+      Object.entries(secret.data).map(([key, value]) => [
+        key,
+        looksBase64(value) ? Buffer.from(value, 'base64').toString('utf8') : value
+      ])
+    )
+  }
+
+  async validate() {
+    return true
+  }
+
+  async get(kind: string, name: string, namespace: string) {
+    this.getCalls.push({ kind, name, namespace })
+    return this.objects.get(keyFor(kind, name, namespace)) ?? null
+  }
+
+  async diff() {
+    return null
+  }
+
+  async list() {
+    return []
+  }
+
+  async delete(kind: string, name: string, namespace: string) {
+    this.deleted.push({ kind, name, namespace })
+    return `${kind}/${name}`
+  }
+
+  async waitForJob(name: string, namespace: string, options?: { timeoutSeconds?: number }) {
+    this.waited.push({ name, namespace, timeoutSeconds: options?.timeoutSeconds })
+  }
+}
+
+function keyFor(kind: string, name: string, namespace: string) {
+  return `${kind}:${namespace}:${name}`
+}
+
+function secret(name: string, namespace: string, data: Record<string, string>, type = 'Opaque') {
+  return {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    type,
+    metadata: { name, namespace },
+    data
+  } as unknown as SupportedManifest
+}
+
+function looksBase64(value: string) {
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(value) && value.length % 4 === 0
+}
+
+function decodeSecretData(manifest: SupportedManifest) {
+  const data = (manifest as unknown as { data?: Record<string, string> }).data ?? {}
+  return Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [key, Buffer.from(value, 'base64').toString('utf8')])
+  )
+}
+
+function makeTsOps(config: ReturnType<typeof makePreviewConfig>, kubectl: FakeKubectl) {
+  return new TsOps(config as any, {
+    docker: noopDocker,
+    kubectl,
+    logger: noopLogger
+  })
+}
+
+function makePreviewConfig(previewOverrides: Record<string, unknown> = {}) {
+  return defineConfig({
+    project: 'worken-preview',
+    namespaces: {
+      'ru-stage': {
+        domain: 'stage.worken.ru'
+      },
+      preview: {
+        extends: 'ru-stage' as const,
+        naming: ({ pr }: { pr: string }) => `pr-${pr}`,
+        domain: ({ pr }: { pr: string }) => `pr-${pr}.stage.worken.ru`,
+        fallback: 'ru-stage' as const,
+        ...previewOverrides
+      }
+    },
+    clusters: {
+      stage: {
+        apiServer: 'https://stage:6443',
+        context: 'stage',
+        namespaces: ['ru-stage', 'preview'] as const
+      }
+    },
+    images: {
+      registry: 'ghcr.io/worken',
+      tagStrategy: 'git-sha' as const
+    },
+    apps: {
+      'worken-api': {
+        image: 'ghcr.io/worken/worken-api:test',
+        ingress: ({ domain }: { domain: string }) => ({ domain: `api.${domain}` }),
+        ports: [{ name: 'http', port: 80, targetPort: 3000 }]
+      }
+    }
+  })
+}
+
+function applied(kubectl: FakeKubectl, kind: string, name?: string) {
+  return kubectl.applied
+    .map((item) => item.manifest)
+    .filter((manifest) => manifest.kind === kind && (!name || manifest.metadata?.name === name))
+}
+
+describe('overlay lifecycle preview contract', () => {
+  it('copies wildcard TLS from explicit sourceNamespace before public routes are applied', async () => {
+    const kubectl = new FakeKubectl()
+    kubectl.seed(
+      secret(
+        'stage-worken-ru-wildcard-tls',
+        'kube-system',
+        { 'tls.crt': 'crt', 'tls.key': 'key' },
+        'kubernetes.io/tls'
+      )
+    )
+
+    const config = makePreviewConfig({
+      cert: {
+        mode: 'wildcard-shared',
+        secretName: 'stage-worken-ru-wildcard-tls',
+        sourceNamespace: 'kube-system',
+        copyToOverlayNamespace: true
+      }
+    })
+    await makeTsOps(config, kubectl).deploy({ namespace: 'preview', vars: { pr: '857' } })
+
+    expect(kubectl.getCalls).toContainEqual({
+      kind: 'Secret',
+      name: 'stage-worken-ru-wildcard-tls',
+      namespace: 'kube-system'
+    })
+    const copied = applied(kubectl, 'Secret', 'stage-worken-ru-wildcard-tls')[0] as any
+    expect(copied.metadata.namespace).toBe('pr-857')
+    expect(copied.type).toBe('kubernetes.io/tls')
+
+    const copyIndex = kubectl.applied.findIndex(
+      ({ manifest }) =>
+        manifest.kind === 'Secret' && manifest.metadata?.name === 'stage-worken-ru-wildcard-tls'
+    )
+    const routeIndex = kubectl.applied.findIndex(({ manifest }) => manifest.kind === 'Ingress')
+    expect(copyIndex).toBeGreaterThan(-1)
+    expect(routeIndex).toBeGreaterThan(copyIndex)
+  })
+
+  it('fails closed and attaches Traefik BasicAuth middleware to every public preview route', async () => {
+    const missing = new FakeKubectl()
+    const config = makePreviewConfig({
+      access: {
+        mode: 'traefik-basic-auth',
+        sourceNamespace: 'kube-system',
+        secretName: 'preview-basic-auth',
+        middlewareName: ({ pr }: { pr: string }) => `preview-basic-auth-pr-${pr}`,
+        attachTo: 'all-public-routes',
+        failClosed: true
+      }
+    })
+
+    await expect(
+      makeTsOps(config, missing).deploy({ namespace: 'preview', vars: { pr: '857' } })
+    ).rejects.toThrow(/preview-basic-auth.*kube-system/)
+
+    const kubectl = new FakeKubectl()
+    kubectl.seed(secret('preview-basic-auth', 'kube-system', { users: 'hashed-users' }))
+
+    await makeTsOps(config, kubectl).deploy({ namespace: 'preview', vars: { pr: '857' } })
+
+    const copied = applied(kubectl, 'Secret', 'preview-basic-auth')[0] as any
+    expect(copied.metadata.namespace).toBe('pr-857')
+    const middleware = applied(kubectl, 'Middleware', 'preview-basic-auth-pr-857')[0] as any
+    expect(middleware.spec.basicAuth.secret).toBe('preview-basic-auth')
+
+    for (const ingress of applied(kubectl, 'Ingress') as any[]) {
+      expect(ingress.metadata.annotations['traefik.ingress.kubernetes.io/router.middlewares']).toBe(
+        'pr-857-preview-basic-auth-pr-857@kubernetescrd'
+      )
+    }
+  })
+
+  it('applies ResourceQuota and LimitRange before preview app workloads', async () => {
+    const kubectl = new FakeKubectl()
+    const config = makePreviewConfig({
+      namespacePolicy: {
+        resourceQuota: {
+          pods: 25,
+          secrets: 50,
+          jobs: 20,
+          requestsCpu: '4',
+          requestsMemory: '8Gi',
+          limitsCpu: '8',
+          limitsMemory: '16Gi',
+          persistentVolumeClaims: 0
+        },
+        limitRange: {
+          defaultRequestCpu: '100m',
+          defaultRequestMemory: '256Mi',
+          defaultLimitCpu: '500m',
+          defaultLimitMemory: '1Gi'
+        }
+      }
+    })
+
+    await makeTsOps(config, kubectl).deploy({ namespace: 'preview', vars: { pr: '857' } })
+
+    const kinds = kubectl.applied.map(({ manifest }) => manifest.kind)
+    expect(kinds).toContain('ResourceQuota')
+    expect(kinds).toContain('LimitRange')
+    expect(kinds.indexOf('ResourceQuota')).toBeLessThan(kinds.indexOf('Deployment'))
+    expect(kinds.indexOf('LimitRange')).toBeLessThan(kinds.indexOf('Deployment'))
+  })
+
+  it('injects generated per-preview runtime database secret refs into app pods', async () => {
+    const config = makePreviewConfig({
+      database: {
+        lifecycleUrlSecret: {
+          name: 'stage-db-lifecycle',
+          key: 'DATABASE_URL',
+          sourceNamespace: 'kube-system'
+        },
+        runtimeSecret: {
+          mode: 'generated-per-overlay',
+          name: ({ pr }: { pr: string }) => `pr-${pr}-db-app`,
+          key: 'DATABASE_URL'
+        },
+        runtimeRole: ({ pr }: { pr: string }) => `worken_pr_${pr}_app`,
+        schema: ({ pr }: { pr: string }) => `pr_${pr}`,
+        preDeploy: 'create-schema',
+        postDestroy: 'drop-schema'
+      }
+    })
+
+    const plan = await makeTsOps(config, new FakeKubectl()).plan({
+      namespace: 'preview',
+      vars: { pr: '857' }
+    })
+    const entry = plan.entries.find((item) => item.app === 'worken-api')
+    if (!entry) throw new Error('Expected worken-api plan entry')
+    expect(entry.env.DATABASE_SCHEMA).toBe('pr_857')
+    expect(entry.env.DATABASE_RUNTIME_ROLE).toBe('worken_pr_857_app')
+    expect(entry.env.DATABASE_URL).toEqual({
+      __type: 'SecretRef',
+      secretName: 'pr-857-db-app',
+      key: 'DATABASE_URL'
+    })
+  })
+
+  it('creates generated per-preview runtime database secret before database hooks and app rollout', async () => {
+    const kubectl = new FakeKubectl()
+    kubectl.seed(
+      secret('stage-db-lifecycle', 'kube-system', {
+        DATABASE_URL:
+          'postgresql://stage_admin:adminpass@postgres.stage:5432/worken?sslmode=require'
+      })
+    )
+
+    const config = makePreviewConfig({
+      database: {
+        lifecycleUrlSecret: {
+          name: 'stage-db-lifecycle',
+          key: 'DATABASE_URL',
+          sourceNamespace: 'kube-system'
+        },
+        runtimeSecret: {
+          mode: 'generated-per-overlay',
+          name: ({ pr }: { pr: string }) => `pr-${pr}-db-app`,
+          key: 'DATABASE_URL'
+        },
+        runtimeRole: ({ pr }: { pr: string }) => `worken_pr_${pr}_app`,
+        schema: ({ pr }: { pr: string }) => `pr_${pr}`,
+        preDeploy: {
+          mode: 'job',
+          name: ({ pr }: { pr: string }) => `preview-db-prepare-pr-${pr}`,
+          image: 'ghcr.io/worken/preview-db-prepare:test'
+        },
+        postDestroy: 'drop-schema'
+      }
+    })
+
+    await makeTsOps(config, kubectl).deploy({
+      namespace: 'preview',
+      vars: { pr: '857' }
+    })
+
+    const runtimeSecret = applied(kubectl, 'Secret', 'pr-857-db-app')[0] as any
+    expect(runtimeSecret.metadata.namespace).toBe('pr-857')
+    const runtimeData = decodeSecretData(runtimeSecret)
+    expect(runtimeData.DATABASE_URL).toMatch(
+      /^postgresql:\/\/worken_pr_857_app:[^@]+@postgres\.stage:5432\/worken\?sslmode=require$/
+    )
+    expect(runtimeData.DATABASE_URL).not.toContain('stage_admin')
+    expect(runtimeData.DATABASE_URL).not.toContain('adminpass')
+    expect(runtimeData.DATABASE_SCHEMA).toBe('pr_857')
+    expect(runtimeData.DATABASE_RUNTIME_ROLE).toBe('worken_pr_857_app')
+    expect(runtimeData.DATABASE_PASSWORD).toMatch(/^[A-Za-z0-9_-]{32,}$/)
+
+    const job = applied(kubectl, 'Job', 'preview-db-prepare-pr-857')[0] as any
+    const env = Object.fromEntries(
+      job.spec.template.spec.containers[0].env.map((item: any) => [
+        item.name,
+        item.value ?? item.valueFrom
+      ])
+    )
+    expect(env.DATABASE_RUNTIME_URL.secretKeyRef).toEqual({
+      name: 'pr-857-db-app',
+      key: 'DATABASE_URL'
+    })
+    expect(env.DATABASE_RUNTIME_PASSWORD.secretKeyRef).toEqual({
+      name: 'pr-857-db-app',
+      key: 'DATABASE_PASSWORD'
+    })
+
+    const runtimeSecretIndex = kubectl.applied.findIndex(
+      ({ manifest }) => manifest.kind === 'Secret' && manifest.metadata?.name === 'pr-857-db-app'
+    )
+    const jobIndex = kubectl.applied.findIndex(
+      ({ manifest }) =>
+        manifest.kind === 'Job' && manifest.metadata?.name === 'preview-db-prepare-pr-857'
+    )
+    const deploymentIndex = kubectl.applied.findIndex(
+      ({ manifest }) => manifest.kind === 'Deployment'
+    )
+    expect(runtimeSecretIndex).toBeGreaterThan(-1)
+    expect(jobIndex).toBeGreaterThan(runtimeSecretIndex)
+    expect(deploymentIndex).toBeGreaterThan(jobIndex)
+  })
+
+  it('runs named job-mode database hooks with vars, generated runtime metadata, and timeout', async () => {
+    const kubectl = new FakeKubectl()
+    kubectl.seed(secret('stage-db-lifecycle', 'kube-system', { DATABASE_URL: 'postgres://stage' }))
+
+    const config = makePreviewConfig({
+      database: {
+        lifecycleUrlSecret: {
+          name: 'stage-db-lifecycle',
+          key: 'DATABASE_URL',
+          sourceNamespace: 'kube-system'
+        },
+        runtimeSecret: {
+          mode: 'generated-per-overlay',
+          name: ({ pr }: { pr: string }) => `pr-${pr}-db-app`,
+          key: 'DATABASE_URL'
+        },
+        runtimeRole: ({ pr }: { pr: string }) => `worken_pr_${pr}_app`,
+        schema: ({ pr }: { pr: string }) => `pr_${pr}`,
+        preDeploy: {
+          mode: 'job',
+          name: ({ pr }: { pr: string }) => `preview-db-prepare-pr-${pr}`,
+          image: 'ghcr.io/worken/preview-db-prepare:test',
+          timeoutSeconds: 600,
+          env: ({ seed }: { seed?: string }) => ({
+            PREVIEW_SEED_MODE: seed ?? 'demo'
+          }),
+          logs: 'tail-on-failure'
+        },
+        postDestroy: 'drop-schema'
+      }
+    })
+
+    await makeTsOps(config, kubectl).deploy({
+      namespace: 'preview',
+      vars: { pr: '857', seed: 'demo' }
+    })
+
+    const copied = applied(kubectl, 'Secret', 'stage-db-lifecycle')[0] as any
+    expect(copied.metadata.namespace).toBe('pr-857')
+    const job = applied(kubectl, 'Job', 'preview-db-prepare-pr-857')[0] as any
+    const env = Object.fromEntries(
+      job.spec.template.spec.containers[0].env.map((item: any) => [
+        item.name,
+        item.value ?? item.valueFrom
+      ])
+    )
+    expect(env.DATABASE_SCHEMA).toBe('pr_857')
+    expect(env.DATABASE_RUNTIME_ROLE).toBe('worken_pr_857_app')
+    expect(env.DATABASE_RUNTIME_SECRET_NAME).toBe('pr-857-db-app')
+    expect(env.PREVIEW_SEED_MODE).toBe('demo')
+    expect(env.DATABASE_URL.secretKeyRef).toEqual({
+      name: 'stage-db-lifecycle',
+      key: 'DATABASE_URL'
+    })
+    expect(kubectl.waited).toContainEqual({
+      name: 'preview-db-prepare-pr-857',
+      namespace: 'pr-857',
+      timeoutSeconds: 600
+    })
+  })
+
+  it('supports overlay runtime variable validation so raw integrations=real fails closed in V1', () => {
+    const config = makePreviewConfig({
+      validateVars: ({ integrations }: { integrations?: string }) => {
+        if (integrations === 'real') {
+          throw new Error('real integrations are not enabled for V1 preview overlays')
+        }
+      }
+    } as any)
+
+    const resolver = createConfigResolver(config)
+    expect(() =>
+      resolver.namespaces.resolve('preview', { pr: '857', integrations: 'real' })
+    ).toThrow(/real integrations are not enabled/)
+  })
+})

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,6 +8,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@tsops/core": "workspace:*",
     "tsops": "workspace:*"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
-      "inputs": ["src/**", "tsconfig.json"]
+      "inputs": ["src/**", "tsconfig.json", "package.json", "../../tsconfig.json"]
     },
     "test": {
       "dependsOn": ["build"],


### PR DESCRIPTION
Follow-up for #47. This PR adds the concrete preview overlay contract needed by Worken PR previews before mono consumes the overlay lifecycle API.

## What changed

- Adds an authoritative preview overlay contract doc under `docs/guide/preview-overlays.md`.
- Extends overlay TLS handling with explicit wildcard source namespace support.
- Adds Traefik BasicAuth access support with fail-closed route protection.
- Adds per-overlay namespace policy resources (`ResourceQuota` and `LimitRange`) before workloads.
- Adds database lifecycle contract support for job-mode preDeploy hooks, hook timeout propagation, lifecycle URL secrets, generated per-overlay runtime DB secrets, and runtime metadata env.
- Injects generated runtime DB Secret refs into app plans so app pods do not consume lifecycle/admin DB credentials.
- Adds overlay runtime var validation so raw `integrations=real` can fail closed in V1 preview configs.
- Updates the preview namespace example to the full Worken-style V1 shape.
- Adds contract tests covering TLS, BasicAuth, quota, DB hook ordering, generated runtime secrets, app env refs, and V1 real-integration rejection.

## Validation

- `pnpm test` passed: 8 test files, 76 tests.
- `pnpm -F tsops-docs build` passed.
- Scoped `pnpm exec biome check ...` passed for the touched source, example, docs, and test files.

## Notes

I do not have push permission to `Pom4H/tsops`, so this targets `feat/overlay-hooks` directly and can be merged into the #47 branch by the repo owner.
