### PR TITLE
docs: refresh README + guides; reframe around the typed operational model

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ```bash
-pnpm add tsops
+pnpm add tsops    # or: bun add tsops / npm install tsops
 ```
+
+> Runs on Node.js 20+/22 LTS or Bun 1.1+.
 
 ## What makes tsops different
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
 # tsops
 
-TypeScript-first toolkit for planning, building, and deploying containerized applications.
+**A typed operational model for containerized apps.** One TypeScript file describes your product topology — apps, namespaces, secrets, routes, dependencies — and tsops uses it as the source of truth for builds, manifests, and the runtime config your app imports.
 
 [![npm version](https://badge.fury.io/js/tsops.svg)](https://www.npmjs.com/package/tsops)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## Quick Start
-
 ```bash
-npm install tsops
-
-or
-
 pnpm add tsops
 ```
 
-Then create a `tsops.config.ts` file:
+## What makes tsops different
+
+Most deploy tools generate manifests. tsops also gives your application code a **typed import** of the same configuration:
+
+```ts
+// tsops.config.ts          → input to manifest builder AND runtime helper
+// frontend/src/api.ts      → consumes the same config
+import config from '../tsops.config'
+
+const apiUrl = config.url('api', 'service')   // http://api
+const region = config.env('api', 'AWS_REGION')
+```
+
+Rename an app, change a port, move a service to another namespace — the TypeScript compiler finds every caller in your codebase. No more "wrong service name → 502 in preview".
+
+This is the actual differentiator vs Helm, Kustomize, CDK8s, or Pulumi: tsops is the only one where **the deploy config and the application's runtime config are the same typed object**.
+
+## Quick start
 
 ```typescript
 import { defineConfig } from 'tsops'
@@ -24,8 +35,8 @@ export default defineConfig({
   project: 'orchard',
 
   namespaces: {
-    dev: { domain: 'dev.example.com', production: false },
-    prod: { domain: 'example.com', production: true }
+    dev:  { domain: 'dev.example.com', production: false },
+    prod: { domain: 'example.com',     production: true  }
   },
 
   clusters: {
@@ -44,9 +55,7 @@ export default defineConfig({
 
   secrets: {
     'api-secrets': ({ production }) => ({
-      JWT_SECRET: production
-        ? process.env.JWT_SECRET ?? ''
-        : 'dev-secret'
+      JWT_SECRET: production ? process.env.JWT_SECRET ?? '' : 'dev-secret'
     })
   },
 
@@ -57,166 +66,120 @@ export default defineConfig({
         context: './apps/api',
         dockerfile: './apps/api/Dockerfile'
       },
-      // Simple object format - protocol auto-detects based on domain
       ingress: ({ domain }) => ({ domain: `api.${domain}` }),
-      // Or explicit: protocol: production ? 'https' : 'http'
       ports: [{ name: 'http', port: 80, targetPort: 8080 }],
       env: ({ production, secret }) => ({
         NODE_ENV: production ? 'production' : 'development',
-        JWT_SECRET: secret('api-secrets', 'JWT_SECRET'),
-        STRIPE_API_KEY: secret('api-secrets', 'STRIPE_KEY')
-        // ⚠️ Don't put service URLs here! Use DNS directly in your app:
-        // fetch('http://postgres/api') instead of process.env.POSTGRES_URL
+        JWT_SECRET: secret('api-secrets', 'JWT_SECRET')
       })
     }
   }
 })
 ```
 
-Root-level secrets and configMaps execute in Node, so read environment variables directly via `process.env` (or your own helper) instead of the app-level `env()` helper.
-
-Run commands:
-
 ```bash
-# Plan what will be deployed
-tsops plan
-tsops plan --namespace prod --app api
-
-# Build Docker images
-tsops build
-tsops build --app api
-
-# Deploy applications
-tsops deploy --namespace prod
-tsops deploy --namespace prod --app api
+tsops plan    --namespace prod          # diff cluster vs config, validate secrets, list orphans
+tsops build   --app api                 # build & push images
+tsops deploy  --namespace prod          # apply atomically, prune orphans
 ```
 
-`tsops plan` resolves your configuration, validates shared resources once, previews per-app manifest updates with diffs, and lists orphaned resources that would be removed. Add `--dry-run` to inspect without invoking Docker or deployment tools. `tsops deploy` reuses that plan, blocks on missing secret values, applies manifests atomically, and cleans up orphans at the end.
+## The product-topology-first model
 
-## Key Principle
+A typical preview namespace, fallbacks, BasicAuth, per-PR DB schema, TLS — without tsops you assemble it from Helm + Kustomize + GitHub Actions YAML + glue scripts. The pattern is well-known. The pain isn't the pattern — it's that the operational model lives in seven places and the compiler can't see any of them.
 
-**tsops embraces Service Discovery.** Don't hardcode service URLs in ENV variables—use internal DNS directly in your application code. ENV is for secrets, external APIs, and configuration, not for internal service endpoints.
+`worken-api` is repeated in:
 
-## Features
+- Helm values
+- Service & IngressRoute backends
+- ExternalName fallbacks
+- CI matrix
+- Secret keys
+- Cleanup scripts
+- Application ENV
 
-- 🎯 **Type-safe configuration** - Full TypeScript support with autocompletion
-- 📋 **Diff-first planning** - Validate namespaces/secrets/configMaps once and preview manifest updates
-- 🐳 **Docker integration** - Build and push images automatically
-- 🌐 **Manifests & networking** - Generate deployments, services, and ingress from a single definition
-- 🔒 **Secret validation** - Catch placeholders and missing keys before deploy
-- 🧹 **Orphan cleanup** - Detect and delete resources not declared in code
-- 🔗 **Service Discovery First** - Encourages proper internal DNS patterns
+Errors are runtime: wrong service name → 502, wrong fallback target → preview talks to staging, missing BasicAuth annotation → public preview leaks integrations.
 
-## Documentation
+tsops moves all of this into one typed graph:
 
-Full documentation is available at [GitHub Pages](https://pom4h.github.io/tsops/)
+```
+Without tsops:  Kubernetes-first  →  product semantics encoded by conventions
+With tsops:     Product topology  →  Kubernetes generated as execution backend
+```
+
+The same compiler that protects your application code now protects your operational model.
+
+## Design-time guarantees
+
+| Surface                  | Without tsops                | With tsops                     |
+|--------------------------|------------------------------|--------------------------------|
+| Service URL in app       | string in `.env`             | `config.url('api', 'service')` |
+| Renaming an app          | grep + hope                  | compile error in every caller  |
+| Missing secret value     | CrashLoopBackOff at runtime  | `tsops plan` blocks deploy     |
+| Drift detection          | manual audit                 | orphan report on every plan    |
+| Cross-namespace fallback | ExternalName YAML            | typed overlay configuration    |
+| Preview env lifecycle    | bash + GitHub Actions        | `tsops up/down`                |
+
+## Preview overlays
+
+PR-style preview namespaces (`pr-857`) are first-class. One overlay declaration covers TLS, BasicAuth, ResourceQuota, per-PR DB schema with pre-deploy migration job, runtime secret generation, and post-destroy cleanup. See [`docs/guide/preview-overlays.md`](./docs/guide/preview-overlays.md).
+
+```bash
+tsops up   preview --var pr=857
+tsops down preview --var pr=857
+```
+
+## Service discovery, done right
+
+`config.url(app, scope)` resolves to the right DNS for the active runtime:
+
+```ts
+config.url('api', 'service')   // http://api                              (same namespace)
+config.url('api', 'cluster')   // http://api.prod.svc.cluster.local       (cross-namespace)
+config.url('api', 'ingress')   // https://api.example.com                 (public)
+```
+
+Active namespace is selected by `TSOPS_NAMESPACE`. Same code runs in production, preview, and locally — no `BACKEND_URL` env to misconfigure.
+
+## Honest trade-offs
+
+- **Opinionated topology.** tsops models `apps × namespaces × clusters`. If your topology doesn't fit, you'll fight the framework.
+- **Application layer only.** Platform components (Traefik, cert-manager, external-secrets, ArgoCD) still live in Helm. tsops covers what you ship, not the cluster you ship it to.
+- **No state file.** Drift is detected via labels (`tsops/managed=true`) and orphan scanning, not a Pulumi/Terraform-style state. Convention, not contract.
+- **Node.js runtime.** Adapters live in `@tsops/node`. The core (`@tsops/core`) is platform-agnostic if you need to port elsewhere.
 
 ## Packages
 
-This is a monorepo containing:
+- **`tsops`** — CLI and `defineConfig`
+- **`@tsops/core`** — orchestrator, resolvers, planner (platform-agnostic)
+- **`@tsops/node`** — Docker / kubectl / Git-aware adapters
+- **`@tsops/k8`** — typed Kubernetes manifest builders (Deployment, Service, Ingress, Traefik IngressRoute, Certificate)
 
-- **`tsops`** – CLI and configuration helper exports
-- **`@tsops/core`** – Core library with programmatic API
-- **`@tsops/node`** – Node-specific adapters and `createNodeTsOps`
-- **`@tsops/k8`** – Manifest builders for Kubernetes
+## Why this matters for AI agents
+
+Tribal knowledge ("don't touch this Helm value", "remember to attach the BasicAuth middleware") cannot be transferred to an LLM agent — it isn't written down anywhere. Typed contracts can. The more of your infra changes are made by Renovate, Dependabot, Claude Code, or Copilot Workspace, the more the value of tsops compounds.
+
+A typed operational model is a model that an agent can safely modify.
+
+## Documentation
+
+Full docs: <https://pom4h.github.io/tsops/>
+
+- [What is tsops?](./docs/guide/what-is-tsops.md)
+- [Getting started](./docs/guide/getting-started.md)
+- [Context helpers](./docs/guide/context-helpers.md)
+- [Secrets & ConfigMaps](./docs/guide/secrets.md)
+- [Preview overlays](./docs/guide/preview-overlays.md)
+- [Architecture](./ARCHITECTURE.md)
 
 ## Development
 
 ```bash
-# Install dependencies
 pnpm install
-
-# Build all packages
-pnpm build
-
-# Run in watch mode
+pnpm build           # build all packages
 pnpm build:watch
-
-# Lint
 pnpm lint
-
-# Run docs locally
-pnpm docs:dev
+pnpm docs:dev        # docs locally at http://localhost:5173/tsops/
 ```
-
-## Service Discovery (Important!)
-
-**⚠️ Anti-pattern: Do NOT use ENV variables for service-to-service communication endpoints.**
-
-Hardcoding service URLs in ENV breaks the Service Discovery pattern and creates tight coupling. Instead, use the runtime config helpers in your application code.
-
-### ❌ Wrong: Hardcoding in ENV
-
-```typescript
-// DON'T DO THIS
-env: () => ({
-  BACKEND_URL: 'http://backend:3000'  // ❌ Hardcoded!
-})
-
-// In your app:
-fetch(process.env.BACKEND_URL)  // ❌ Not type-safe, breaks namespace switching
-```
-
-**Problems:**
-- Breaks Service Discovery
-- Not type-safe
-- Doesn't respect `TSOPS_NAMESPACE`
-- Hardcoded ports and hostnames
-
-### ✅ Correct: Use runtime config
-
-```typescript
-// In your app code:
-import config from './tsops.config'
-
-// Short DNS (same namespace)
-const BACKEND_URL = config.url('backend', 'service')  // http://backend
-// Or full cluster DNS (cross-namespace safe):
-const BACKEND_URL = config.url('backend', 'cluster')  // http://backend.prod.svc.cluster.local
-
-fetch(`${BACKEND_URL}/api/data`)  // ✅ Type-safe, namespace-aware!
-```
-
-**Benefits:**
-- Type-safe (compile-time checking)
-- Respects `TSOPS_NAMESPACE` environment variable
-- Single source of truth
-- Platform handles service resolution automatically
-- Zero-downtime deployments work correctly
-
-### When to use ENV
-
-Use ENV variables **only** for:
-- **Secrets**: API keys, passwords, tokens
-- **External services**: Third-party APIs, databases outside the cluster
-- **Feature flags**: Application behavior configuration
-- **Build-time values**: Version numbers, git commits
-
-```typescript
-env: ({ secret, env }) => ({
-  JWT_SECRET: secret('api-secrets', 'JWT_SECRET'),    // ✅ Secret
-  STRIPE_API_KEY: secret('payment', 'STRIPE_KEY'),    // ✅ Secret
-  EXTERNAL_API: 'https://api.external.com',           // ✅ External service
-  DATABASE_HOST: env('EXTERNAL_DB_HOST'),             // ✅ External database
-  LOG_LEVEL: 'info',                                  // ✅ Config
-  GIT_SHA: env('GIT_SHA', 'dev')                      // ✅ Build-time value
-})
-```
-
-**Never** put internal service URLs in ENV - use `config.url()` in runtime instead.
-
-## Runtime Helpers
-
-Import the compiled config in your application to reuse resolved values at runtime. The active namespace is selected via the `TSOPS_NAMESPACE` environment variable (defaults to the first namespace).
-
-```typescript
-import config from './tsops.config.js'
-
-const nodeEnv = config.env('api', 'NODE_ENV')
-const external = config.url('api', 'ingress') // https://api.dev.example.com (public endpoint)
-```
-
-**Note:** Runtime helpers are primarily for getting public ingress URLs, not for service-to-service communication (use DNS directly for that).
 
 ## License
 
@@ -224,4 +187,4 @@ MIT © Roman Popov
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+PRs welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         text: `v${cliPkg.version}`, 
         items: [
           { text: 'Changelog', link: 'https://github.com/Pom4H/tsops/blob/main/CHANGELOG.md' },
-          { text: 'Contributing', link: '/guide/contributing' }
+          { text: 'Contributing', link: 'https://github.com/Pom4H/tsops/blob/main/CONTRIBUTING.md' }
         ]
       }
     ],
@@ -51,20 +51,14 @@ export default defineConfig({
         {
           text: 'Core Concepts',
           items: [
-            { text: 'Configuration', link: '/guide/configuration' },
             { text: 'Context Helpers', link: '/guide/context-helpers' },
             { text: 'Secrets & ConfigMaps', link: '/guide/secrets' },
-            { text: 'Networking', link: '/guide/networking' },
-            { text: 'Building Images', link: '/guide/building' },
           ]
         },
         {
           text: 'Advanced',
           items: [
-            { text: 'Secret Validation', link: '/guide/secret-validation' },
-            { text: 'Multi-Environment', link: '/guide/multi-environment' },
-            { text: 'Monorepo Setup', link: '/guide/monorepo' },
-            { text: 'CI/CD Integration', link: '/guide/cicd' },
+            { text: 'Preview Overlays', link: '/guide/preview-overlays' },
           ]
         }
       ],
@@ -84,9 +78,6 @@ export default defineConfig({
           text: 'API Reference',
           items: [
             { text: 'Overview', link: '/api/' },
-            { text: 'defineConfig', link: '/api/define-config' },
-            { text: 'Context Helpers', link: '/api/context-helpers' },
-            { text: 'CLI Commands', link: '/api/cli' },
           ]
         }
       ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,6 @@ See `.github/workflows/deploy-docs.yml` for details.
 
 ## Links
 
-- Live docs: https://yourusername.github.io/tsops/
+- Live docs: https://pom4h.github.io/tsops/
 - VitePress docs: https://vitepress.dev/
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -275,15 +275,19 @@ export default defineConfig({
 - [Monitoring](/examples/monitoring) - Observability stack
 - [Monorepo](/examples/monorepo) - Multi-app repo
 
-## Example Repository
+## Runnable examples
 
-All examples are available in the [tsops-examples](https://github.com/yourusername/tsops-examples) repository.
+All examples live in the main repo under [`examples/`](https://github.com/Pom4H/tsops/tree/main/examples):
+
+- `examples/fullstack` — frontend + backend in Docker Desktop
+- `examples/monorepo` — multi-package project
+- `examples/otel` — OpenTelemetry collector
+- `examples/preview-namespaces` — PR preview overlays
 
 ```bash
-git clone https://github.com/yourusername/tsops-examples
-cd tsops-examples/simple-app
-pnpm install
-pnpm tsops plan
+git clone https://github.com/Pom4H/tsops
+cd tsops && pnpm install
+pnpm --filter @example/fullstack tsops plan
 ```
 
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,6 +99,23 @@ Add to your `package.json`:
 }
 ```
 
+## Use the config from your app
+
+The same `tsops.config.ts` is consumed by your application code at runtime. This is the differentiator — not just typed manifests, but a typed operational model your app actually imports.
+
+```ts
+// apps/api/src/index.ts
+import config from '../../tsops.config'
+
+// Service-to-service URL, namespace-aware
+const dbUrl = config.url('postgres', 'service')
+
+// Resolved env value for this app
+const nodeEnv = config.env('api', 'NODE_ENV')
+```
+
+`TSOPS_NAMESPACE` selects the active namespace at runtime. Same code runs in `prod`, in a `pr-857` preview namespace, and locally.
+
 ## Deploy Your App
 
 ### Step 1: Plan
@@ -220,6 +237,6 @@ pnpm add -D typescript
 ## Getting Help
 
 - 📖 [Documentation](/guide/what-is-tsops)
-- 💬 [GitHub Discussions](https://github.com/yourusername/tsops/discussions)
-- 🐛 [Report Bug](https://github.com/yourusername/tsops/issues)
-- 💡 [Feature Request](https://github.com/yourusername/tsops/issues/new?template=feature_request.md)
+- 💬 [GitHub Discussions](https://github.com/Pom4H/tsops/discussions)
+- 🐛 [Report Bug](https://github.com/Pom4H/tsops/issues)
+- 💡 [Feature Request](https://github.com/Pom4H/tsops/issues/new)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,10 +25,6 @@ bun add tsops
 npm install tsops
 ```
 
-```bash [yarn]
-yarn add tsops
-```
-
 :::
 
 > tsops itself is runtime-agnostic — the CLI runs on either Node.js or Bun.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -4,21 +4,25 @@ Get up and running with tsops in minutes.
 
 ## Prerequisites
 
-- Node.js 18+ or 20+
+- Node.js 20+ or 22 LTS, **or** Bun 1.1+
 - Docker (for building images)
 - kubectl configured with cluster access
-- TypeScript knowledge
+- TypeScript 5.x
 
 ## Installation
 
 ::: code-group
 
-```bash [npm]
-npm install tsops
-```
-
 ```bash [pnpm]
 pnpm add tsops
+```
+
+```bash [bun]
+bun add tsops
+```
+
+```bash [npm]
+npm install tsops
 ```
 
 ```bash [yarn]
@@ -26,6 +30,9 @@ yarn add tsops
 ```
 
 :::
+
+> tsops itself is runtime-agnostic — the CLI runs on either Node.js or Bun.
+> Pick whichever your project already uses.
 
 ## Create Configuration
 
@@ -59,7 +66,7 @@ export default defineConfig({
   },
   
   images: {
-    registry: 'ghcr.io/yourorg',
+    registry: 'ghcr.io/example',
     tagStrategy: 'git-sha'
   },
   
@@ -140,7 +147,7 @@ Sample output:
 📦 Application Resources
 
    api @ production (api.example.com)
-   Image: ghcr.io/yourorg/api:abc123
+   Image: ghcr.io/example/api:abc123
 
       ➕ Will create:
          • Deployment/my-app-api

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -4,9 +4,21 @@ Deploy your first containerized app in 5 minutes.
 
 ## 1. Install
 
-```bash
+::: code-group
+
+```bash [pnpm]
 pnpm add tsops
 ```
+
+```bash [bun]
+bun add tsops
+```
+
+```bash [npm]
+npm install tsops
+```
+
+:::
 
 ## 2. Create Config
 
@@ -34,7 +46,7 @@ export default defineConfig({
   },
   
   images: {
-    registry: 'ghcr.io/yourorg',
+    registry: 'ghcr.io/example',
     tagStrategy: 'git-sha'
   },
   

--- a/docs/guide/what-is-tsops.md
+++ b/docs/guide/what-is-tsops.md
@@ -1,165 +1,193 @@
 # What is tsops?
 
-**tsops** is a TypeScript-first toolkit for planning, building, and deploying containerized applications. It replaces YAML configurations with type-safe TypeScript code, giving you the power of a programming language while maintaining the simplicity of declarative configuration.
+**tsops is a typed operational model for containerized applications.**
 
-## The Problem
+You describe your product topology in TypeScript — apps, namespaces, secrets, ports, routes, dependencies, overlays. tsops uses that single description as the source of truth for three different things:
 
-Deploying containerized applications traditionally involves:
+1. **Builds** — what images to build and tag
+2. **Manifests** — what to apply to Kubernetes
+3. **Runtime config** — what your application code imports to find services and secrets
 
-- ❌ Writing repetitive YAML files
-- ❌ Copying and pasting configurations
-- ❌ Hardcoding service names, domains, and DNS
-- ❌ Managing secrets separately from deployment
-- ❌ No type safety or validation until runtime
-- ❌ Difficult to maintain across environments
+The third item is the one that matters. It's also what no other tool gives you.
 
-## The tsops Solution
+## The problem tsops solves
 
-tsops provides:
+A working preview-environment-with-fallbacks setup is not hard to design. An experienced DevOps engineer can sketch it in an afternoon:
 
-- ✅ **Type-safe configuration** - Catch errors at compile time
-- ✅ **Context helpers** - secret(), configMap(), env()
-- ✅ **Single source of truth** - Define once, use everywhere
-- ✅ **Secret validation** - Automatic checks before deployment
-- ✅ **Built-in Docker** - Build and push images
-- ✅ **Multi-environment** - Easy dev/staging/prod management
+```
+PR #123 → CI → namespace pr-123 → real deploys for changed apps
+                                → ExternalName fallbacks for the rest
+                                → BasicAuth + ResourceQuota
+                                → per-PR DB schema
+                                → preview URL posted back to PR
+```
 
-## How It Works
+The pattern is well-known. The pain isn't the pattern — it's that the operational model lives in seven places and the compiler can't see any of them.
+
+The name `worken-api` ends up repeated in:
+
+- Helm values
+- Service and IngressRoute backends
+- ExternalName fallback targets
+- GitHub Actions matrix
+- Secret keys
+- Cleanup scripts
+- The application's `BACKEND_URL` env
+
+When something drifts, the failure mode is runtime:
+
+| Mistake                              | Symptom                            |
+|--------------------------------------|------------------------------------|
+| Wrong service name in IngressRoute   | 502                                |
+| Wrong secret key                     | Pod CrashLoopBackOff               |
+| Wrong fallback target                | Preview talks to staging backend   |
+| Missing BasicAuth annotation         | Public preview leaks integrations  |
+| Wrong namespace in deploy            | Accidental staging overwrite       |
+
+You can mitigate this with templates, conventions, and CI smoke tests — but the TypeScript compiler is sitting right there, and it can't help, because the operational model isn't TypeScript.
+
+## What tsops actually does
+
+tsops moves the operational model into one typed graph. The same `tsops.config.ts` is consumed by:
+
+```
+                tsops.config.ts
+                /             \
+   manifest builder        runtime helper
+   (kubectl apply)         (your app code)
+```
+
+```ts
+// In your app:
+import config from '../tsops.config'
+
+const apiUrl = config.url('api', 'service')  // http://api
+```
+
+If you rename the `api` app to `core-api` in `tsops.config.ts`, every caller of `config.url('api', ...)` becomes a compile error. Same for `config.env('api', 'JWT_SECRET')` if `JWT_SECRET` disappears from the secret. That's the core idea.
+
+## How it differs from existing tools
+
+| Tool             | Generates manifests | Imported by your app | Catches typos at compile time |
+|------------------|:-------------------:|:--------------------:|:----------------------------:|
+| Helm / Kustomize | ✅                  | ❌                   | ❌                           |
+| CDK8s            | ✅                  | ❌                   | ✅ (deploy side only)        |
+| Pulumi           | ✅                  | ❌                   | ✅ (deploy side only)        |
+| **tsops**        | ✅                  | ✅                   | ✅ (deploy + app)            |
+
+CDK8s and Pulumi solve half the problem: typed manifest generation. They still leave you wiring up `BACKEND_URL` env vars and praying you spelled the service name right. tsops closes that loop.
+
+## The two paradigms, stated plainly
+
+```
+Without tsops:  Kubernetes-first  →  product semantics encoded by conventions
+With tsops:     Product topology  →  Kubernetes generated as execution backend
+```
+
+That's the entire shift. Everything else — the CLI, the planner, the secret validation, the preview overlays — follows from that inversion.
+
+## A minimal example
 
 ```typescript
-// tsops.config.ts
 import { defineConfig } from 'tsops'
 
 export default defineConfig({
-  project: 'my-app',
-  domain: { prod: 'example.com' },
-  
+  project: 'orchard',
+
+  namespaces: {
+    dev:  { domain: 'dev.example.com', production: false },
+    prod: { domain: 'example.com',     production: true  }
+  },
+
+  clusters: {
+    platform: {
+      apiServer: 'https://k8s.example.com',
+      context: 'prod',
+      namespaces: ['dev', 'prod']
+    }
+  },
+
+  images: {
+    registry: 'ghcr.io/example',
+    tagStrategy: 'git-sha'
+  },
+
+  secrets: {
+    'api-secrets': ({ production }) => ({
+      JWT_SECRET: production ? process.env.JWT_SECRET ?? '' : 'dev-secret'
+    })
+  },
+
   apps: {
     api: {
+      build: { type: 'dockerfile', context: './apps/api', dockerfile: './apps/api/Dockerfile' },
       ingress: ({ domain }) => ({ domain: `api.${domain}` }),
-      env: () => ({
-        // ✅ In your app: config.url('postgres', 'service')
+      ports: [{ name: 'http', port: 80, targetPort: 8080 }],
+      env: ({ secret }) => ({
+        JWT_SECRET: secret('api-secrets', 'JWT_SECRET')
       })
     }
   }
 })
 ```
 
+Then:
+
 ```bash
-# Deploy
-$ pnpm tsops deploy --namespace production
+tsops plan --namespace prod
 ```
 
-That's it! tsops:
-1. Resolves your configuration
-2. Builds Docker images (if needed)
-3. Generates deployment manifests
-4. Applies them to your cluster
+```
+📋 Generating deployment plan and validating manifests...
 
-## Key Features
+🌐 Global Resources
+   ➕ Namespaces to create:  prod
+   ✅ Secret/api-secrets:    valid (JWT_SECRET set from env)
 
-### 🎯 Type Safety
+📦 Application Resources
+   api @ prod (api.example.com)
+   Image: ghcr.io/example/orchard-api:abc123
 
-Write configuration in TypeScript with full IntelliSense support. Get instant feedback on typos and type errors.
+      ➕ Will create:
+         • Deployment/orchard-api
+         • Service/orchard-api
+         • Ingress/orchard-api
 
-### ✨ Context Helpers
-
-Built-in helpers for common patterns:
-
-```typescript
-{
-  // ✅ Use runtime config in your app code:
-  import config from './tsops.config'
-  const POSTGRES_URL = config.url('postgres', 'service')
-  // → 'http://postgres' or 'http://my-app-postgres.production.svc.cluster.local'
-  
-  // Use namespace variables for domain
-  ingress: ({ domain }) => ({ domain: `api.${domain}` })
-  // → 'api.example.com'
-  
-  secret('api-secrets')
-  // → envFrom: secretRef
-}
+✅ Validation passed. Run "tsops deploy" to apply.
 ```
 
-### 🔒 Secret Validation
+If `process.env.JWT_SECRET` is missing, `tsops plan` blocks with a typed error before `kubectl` is ever invoked.
 
-Automatic validation before deployment:
+## What tsops gives you, concretely
 
-```typescript
-secrets: {
-  'api-secrets': () => ({
-    JWT_SECRET: process.env.PROD_JWT ?? ''  // ← Validated!
-  })
-}
-```
+- **`tsops plan`** — diff the cluster against your config, validate every secret, list orphans. Errors fail the command.
+- **`tsops deploy`** — apply the planned manifests atomically. Prune orphans tagged `tsops/managed=true`.
+- **`tsops build`** — resolve image references and invoke Docker.
+- **`tsops up/down preview`** — overlay-based PR preview namespaces with TLS, BasicAuth, ResourceQuota, per-PR DB schema, and lifecycle hooks.
+- **`config.url(app, scope)`** — `service` / `cluster` / `ingress` DNS resolution at runtime, namespace-aware via `TSOPS_NAMESPACE`.
+- **`config.env(app, key)`** — typed access to resolved environment for a given app.
+- **Type safety end to end** — IntelliSense for app names, secret keys, namespace variables. Renaming an app is a refactor, not a search-and-replace.
 
-If `PROD_JWT` is missing, tsops:
-1. Checks if secret exists in cluster
-2. Uses cluster secret if available
-3. Shows helpful error if not
+## Honest trade-offs
 
-### 🚀 Single Source of Truth
+- **Opinionated topology.** tsops models `apps × namespaces × clusters` plus overlays. If your topology doesn't fit, you'll fight the framework.
+- **Application layer only.** Platform components — Traefik, cert-manager, external-secrets, ArgoCD, the Postgres operator — still live in Helm. tsops covers what you ship, not the cluster you ship it to.
+- **No state file.** Drift detection is convention-based (`tsops/managed=true` label) and orphan scanning, not a Pulumi/Terraform-style state store.
+- **One config can grow large.** In a 30-service monorepo the config becomes its own subproject that needs to be split across files.
+- **Node.js runtime.** Adapters live in `@tsops/node`. The core (`@tsops/core`) is platform-agnostic if you need to embed it elsewhere.
 
-Use the same config for deployment AND runtime:
+## Why this matters more every year
 
-```typescript
-// Deployment
-env: ({ secret }) => secret('api-secrets')
+The percentage of infrastructure changes made by automated tools — Renovate, Dependabot, Claude Code, Copilot Workspace — is going up, not down.
 
-// Runtime (in your app)
-import config from './tsops.config'
-process.env.TSOPS_NAMESPACE = 'production'
-const nodeEnv = config.env('api', 'NODE_ENV')
-```
+Tribal knowledge ("don't touch this Helm value", "remember to attach the BasicAuth middleware") cannot be transferred to an LLM agent. It isn't written down anywhere. A typed contract can. A typed operational model is one that an agent can safely modify.
 
-## Comparison
+The same compiler that protects your application code, protecting your operational model — that's tsops.
 
-| Feature | YAML | Helm | tsops |
-|---------|------|------|-------|
-| Type Safety | ❌ | ❌ | ✅ |
-| IntelliSense | ❌ | ❌ | ✅ |
-| Functions | ❌ | Limited | ✅ |
-| Validation | Runtime | Runtime | Compile-time |
-| Secret Validation | ❌ | ❌ | ✅ |
-| Context Helpers | ❌ | ❌ | ✅ |
-| Learning Curve | Low | High | Medium |
+## Next
 
-## Who is tsops for?
-
-tsops is perfect for:
-
-- **TypeScript teams** - You already know the language
-- **Platform engineers** - Managing multiple apps and environments
-- **Startups** - Need to move fast with confidence
-- **Teams tired of YAML** - Want type safety and better DX
-
-## Next Steps
-
-<div class="next-steps">
-
-### [🚀 Get Started](/guide/getting-started)
-Install tsops and deploy your first app
-
-### [📖 Context Helpers](/guide/context-helpers)
-Learn about configuration helpers and runtime utilities
-
-### [💡 Examples](/examples/)
-See real-world use cases
-
-</div>
-
-<style>
-.next-steps {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-  margin: 2rem 0;
-}
-
-.next-steps > div {
-  padding: 1.5rem;
-  background: var(--vp-c-bg-soft);
-  border-radius: 8px;
-}
-</style>
+- [Getting started](./getting-started.md)
+- [Quick start](./quick-start.md)
+- [Context helpers](./context-helpers.md)
+- [Secrets & ConfigMaps](./secrets.md)
+- [Preview overlays](./preview-overlays.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,10 +36,6 @@ bun add tsops
 npm install tsops
 ```
 
-```bash [yarn]
-yarn add tsops
-```
-
 ::::
 
 > Works on Node.js 20+/22 LTS and Bun 1.1+ — pick whichever your project already uses.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,23 +24,25 @@ hero:
 
 :::: code-group
 
-```bash [npm]
-npm install tsops
-```
-
 ```bash [pnpm]
 pnpm add tsops
-```
-
-```bash [yarn]
-yarn add tsops
 ```
 
 ```bash [bun]
 bun add tsops
 ```
 
+```bash [npm]
+npm install tsops
+```
+
+```bash [yarn]
+yarn add tsops
+```
+
 ::::
+
+> Works on Node.js 20+/22 LTS and Bun 1.1+ — pick whichever your project already uses.
 
 ## The differentiator
 
@@ -86,7 +88,7 @@ export default defineConfig({
   },
 
   images: {
-    registry: 'ghcr.io/yourorg',
+    registry: 'ghcr.io/example',
     tagStrategy: 'git-sha'
   },
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: "tsops"
-  text: "TypeScript-first deployment toolkit"
-  tagline: Deploy containerized applications with confidence using type-safe configuration
+  text: "A typed operational model for containerized apps"
+  tagline: One TypeScript file describes your product topology — apps, namespaces, secrets, routes, dependencies. tsops uses it as the source of truth for builds, manifests, and the runtime config your app imports.
   image:
     src: /logo.svg
     alt: tsops logo
@@ -13,15 +13,14 @@ hero:
       text: Get Started
       link: /guide/getting-started
     - theme: alt
-      text: View Examples
-      link: /examples/
+      text: What is tsops?
+      link: /guide/what-is-tsops
     - theme: alt
       text: GitHub
       link: https://github.com/Pom4H/tsops
-  
 ---
 
-## Installation
+## Install
 
 :::: code-group
 
@@ -43,56 +42,66 @@ bun add tsops
 
 ::::
 
-## Quick Example
-Create this file at the root of your project as `tsops.config.ts`.
+## The differentiator
+
+Most deploy tools generate manifests. tsops also exposes the same configuration as a **typed import** for your application code:
+
+```ts
+// tsops.config.ts is the input to:
+//   1. the manifest builder    (kubectl apply)
+//   2. the runtime helper      (your app)
+
+import config from './tsops.config'
+
+const apiUrl  = config.url('api', 'service')   // http://api
+const region  = config.env('api', 'AWS_REGION')
+const ingress = config.url('api', 'ingress')   // https://api.example.com
+```
+
+Rename an app, change a port, add a namespace — the TypeScript compiler finds every caller in your codebase. `worken-api` is no longer repeated in seven places that drift independently.
+
+This is what separates tsops from Helm, Kustomize, CDK8s, and Pulumi: **the deploy config and the application's runtime config are the same typed object**.
+
+## Quick example
+
+Create `tsops.config.ts` at your project root:
 
 ```typescript
 import { defineConfig } from 'tsops'
 
 export default defineConfig({
-  project: 'my-app',
-  
+  project: 'orchard',
+
   namespaces: {
-    dev: { domain: 'dev.example.com', production: false },
-    prod: { domain: 'example.com', production: true },
+    dev:  { domain: 'dev.example.com', production: false },
+    prod: { domain: 'example.com',     production: true  }
   },
-  
+
   clusters: {
-    local: {
+    platform: {
       apiServer: 'https://kubernetes.docker.internal:6443',
       context: 'docker-desktop',
       namespaces: ['dev']
     }
   },
-  
+
   images: {
     registry: 'ghcr.io/yourorg',
     tagStrategy: 'git-sha'
   },
-  
+
   apps: {
     web: {
+      build: { type: 'dockerfile', context: './web', dockerfile: './web/Dockerfile' },
       ingress: ({ domain }) => ({ domain }),
-      build: {
-        type: 'dockerfile',
-        context: './web',
-        dockerfile: './web/Dockerfile'
-      },
       env: ({ production }) => ({
         NODE_ENV: production ? 'production' : 'development'
-        // ✅ In your app: config.url('otelCollector', 'service')
       })
     },
     api: {
+      build: { type: 'dockerfile', context: './api', dockerfile: './api/Dockerfile' },
       ingress: ({ domain }) => ({ domain: `api.${domain}` }),
-      build: {
-        type: 'dockerfile',
-        context: './api',
-        dockerfile: './api/Dockerfile'
-      },
-      env: () => ({
-        // ✅ In your app: config.url('otelCollector', 'service')
-      })
+      ports: [{ name: 'http', port: 80, targetPort: 8080 }]
     },
     otelCollector: {
       image: 'otel/opentelemetry-collector:latest'
@@ -101,111 +110,113 @@ export default defineConfig({
 })
 ```
 
+Then:
 
- 
+```bash
+tsops plan    --namespace prod      # validate, diff, list orphans
+tsops build   --app api             # build & push image
+tsops deploy  --namespace prod      # apply atomically
+```
 
-## Use in your app (runtime)
-
-Import your `tsops.config.ts` to access resolved endpoints and configuration at runtime.
+## Use it from your app at runtime
 
 ```ts
-// Example: Using config in your app
 import config from './tsops.config'
 
-// ✅ Public ingress URL (external traffic)
-const publicApiUrl = config.url('api', 'ingress')
-// e.g. https://api.dev.example.com
+// Service-to-service (same namespace)
+const backendUrl = config.url('api', 'service')   // http://api
 
-// ✅ Service-to-service communication (internal)
-const backendUrl = config.url('api', 'service')  // http://api
-// or full DNS:
-const backendUrl = config.url('api', 'cluster')  // http://api.prod.svc.cluster.local
+// Public ingress
+const publicUrl  = config.url('api', 'ingress')   // https://api.example.com
 
 export default async function Page() {
-  const res = await fetch(`${backendUrl}/api/message`, { cache: 'no-store' })
+  const res  = await fetch(`${backendUrl}/api/message`, { cache: 'no-store' })
   const data = res.ok ? await res.json() : { message: `HTTP ${res.status}` }
-  return (
-    <main>
-      <h1>Frontend</h1>
-      <p>Backend says: {data.message}</p>
-    </main>
-  )
+  return <main><p>Backend says: {data.message}</p></main>
 }
 ```
 
-## Why tsops?
+`TSOPS_NAMESPACE` selects the active namespace at runtime. The same code runs in `prod`, in a `pr-857` preview namespace, and locally — no `BACKEND_URL` env to misconfigure.
+
+## Why tsops
 
 <div class="why-grid">
   <div class="why-card">
-    <div class="why-icon">🎯</div>
-    <div class="why-title">TypeScript-First</div>
-    <div class="why-desc">Author deployment strategy in TypeScript with full IntelliSense, literal inference, and compile-time guarantees.</div>
-  </div>
-  <div class="why-card">
-    <div class="why-icon">📋</div>
-    <div class="why-title">Diff-First Planner</div>
-    <div class="why-desc">Use <code>planWithChanges()</code> or the CLI to validate namespaces, view manifest diffs, and spot errors before deploy.</div>
-  </div>
-  <div class="why-card">
-    <div class="why-icon">✨</div>
-    <div class="why-title">Smart Helpers</div>
-    <div class="why-desc">Access helpers like <code>secret()</code>, <code>configMap()</code>, and namespace variables directly inside app definitions.</div>
-  </div>
-  <div class="why-card">
-    <div class="why-icon">🔒</div>
-    <div class="why-title">Secret Guardrails</div>
-    <div class="why-desc">Catch placeholder values and missing keys automatically; reuse existing cluster secrets when appropriate.</div>
-  </div>
-  <div class="why-card">
-    <div class="why-icon">🌐</div>
-    <div class="why-title">Auto Networking</div>
-    <div class="why-desc">Generate ingress and TLS certificates with automatic protocol detection (http for local, https for production).</div>
+    <div class="why-icon">🧭</div>
+    <div class="why-title">Product topology first</div>
+    <div class="why-desc">Describe apps, namespaces, dependencies, and routes once. Manifests are generated as the execution backend, not the source of truth.</div>
   </div>
   <div class="why-card">
     <div class="why-icon">🔁</div>
-    <div class="why-title">Runtime Reuse</div>
-    <div class="why-desc">Import the same config at runtime, switch namespaces with <code>TSOPS_NAMESPACE</code>, and resolve endpoints on demand.</div>
+    <div class="why-title">Single typed object</div>
+    <div class="why-desc">The same <code>config</code> is consumed by the manifest builder and your application code. Rename an app — the compiler finds every caller.</div>
   </div>
   <div class="why-card">
-    <div class="why-icon">⚙️</div>
-    <div class="why-title">CI/CD Ready</div>
-    <div class="why-desc">Git-aware environment providers, deterministic image tags, and <code>--dry-run</code> flows slot neatly into pipelines.</div>
+    <div class="why-icon">📋</div>
+    <div class="why-title">Diff-first planner</div>
+    <div class="why-desc"><code>tsops plan</code> validates secrets, diffs every manifest against the cluster, and lists orphans before anything is applied.</div>
+  </div>
+  <div class="why-card">
+    <div class="why-icon">🌐</div>
+    <div class="why-title">Service discovery</div>
+    <div class="why-desc"><code>config.url(app, scope)</code> resolves to the right DNS for the active namespace. No hardcoded <code>BACKEND_URL</code> strings.</div>
+  </div>
+  <div class="why-card">
+    <div class="why-icon">🔒</div>
+    <div class="why-title">Secret guardrails</div>
+    <div class="why-desc">Placeholders, missing values, and unknown secret keys are caught before <code>kubectl apply</code> ever runs.</div>
+  </div>
+  <div class="why-card">
+    <div class="why-icon">🧪</div>
+    <div class="why-title">Preview overlays</div>
+    <div class="why-desc">PR-style namespaces (<code>pr-857</code>) with TLS, BasicAuth, ResourceQuota, per-PR DB schema, and lifecycle hooks as one typed declaration.</div>
   </div>
   <div class="why-card">
     <div class="why-icon">🧹</div>
-    <div class="why-title">Drift-Free Deployments</div>
-    <div class="why-desc">Automated orphan detection and cleanup keep your cluster in sync with your declared configuration.</div>
+    <div class="why-title">Drift-free deploys</div>
+    <div class="why-desc">Resources tagged <code>tsops/managed=true</code> that disappear from config are flagged as orphans and pruned on deploy.</div>
+  </div>
+  <div class="why-card">
+    <div class="why-icon">🤖</div>
+    <div class="why-title">Agent-safe</div>
+    <div class="why-desc">Tribal knowledge can't be given to an LLM agent. A typed operational model can. Agents that change infra can rely on the compiler.</div>
   </div>
 </div>
 
-## What People Say
+## How it compares
 
-> "tsops transformed our deployment workflow. No more YAML hell, just clean TypeScript configuration."
-> 
-> — *Production User*
+| Tool                | Generates manifests | Imported by your app | Catches typos at compile time |
+|---------------------|:------------------:|:--------------------:|:----------------------------:|
+| Helm / Kustomize    | ✅                 | ❌                    | ❌                           |
+| CDK8s               | ✅                 | ❌                    | ✅ (deploy side only)        |
+| Pulumi              | ✅                 | ❌                    | ✅ (deploy side only)        |
+| **tsops**           | ✅                 | ✅                    | ✅ (deploy + app)            |
 
-> "The secret validation and type-safe configuration saved us hours of debugging."
-> 
-> — *DevOps Engineer*
+## Honest trade-offs
 
-> "Secret validation caught so many issues before they hit production. This tool pays for itself."
-> 
-> — *Platform Team Lead*
+- **Opinionated topology.** tsops models `apps × namespaces × clusters`. If your topology doesn't fit, you'll fight the framework.
+- **Application layer only.** Platform components (Traefik, cert-manager, external-secrets, ArgoCD) still live in Helm.
+- **No state file.** Drift detection is convention-based (`tsops/managed=true` label), not a Terraform-style state.
+- **Node.js runtime.** Adapters live in `@tsops/node`; the core is platform-agnostic if you need to port elsewhere.
 
-## Ready to Get Started?
+## Ready to start?
 
 <div class="cta-grid">
   <div class="cta-card">
-    <a href="/guide/getting-started">📚 Read the Guide</a>
-    <p>Learn the basics and deploy your first app.</p>
+    <a href="/guide/what-is-tsops">📖 What is tsops?</a>
+    <p>The mental model in five minutes.</p>
   </div>
   <div class="cta-card">
-    <a href="/examples/">💡 See Examples</a>
-    <p>Explore monorepo, fullstack, and observability setups.</p>
+    <a href="/guide/getting-started">🚀 Getting started</a>
+    <p>Install and ship your first app.</p>
   </div>
   <div class="cta-card">
-    <a href="/api/">🔧 API Reference</a>
-    <p>Full API for helpers, types, and CLI.</p>
+    <a href="/examples/">💡 Examples</a>
+    <p>Monorepo, full-stack, observability, previews.</p>
+  </div>
+  <div class="cta-card">
+    <a href="/api/">🔧 API reference</a>
+    <p>Helpers, types, and CLI.</p>
   </div>
 </div>
 
@@ -230,20 +241,9 @@ export default async function Page() {
   box-shadow: 0 6px 28px rgba(0,0,0,0.06);
 }
 
-.why-icon {
-  font-size: 1.4rem;
-  line-height: 1;
-}
-
-.why-title {
-  margin-top: 0.6rem;
-  font-weight: 700;
-}
-
-.why-desc {
-  margin-top: 0.35rem;
-  color: var(--vp-c-text-2);
-}
+.why-icon { font-size: 1.4rem; line-height: 1; }
+.why-title { margin-top: 0.6rem; font-weight: 700; }
+.why-desc  { margin-top: 0.35rem; color: var(--vp-c-text-2); }
 
 .cta-grid {
   display: grid;
@@ -266,14 +266,6 @@ export default async function Page() {
   box-shadow: 0 6px 28px rgba(0,0,0,0.06);
 }
 
-.cta-card a {
-  display: inline-block;
-  font-size: 1.05rem;
-  font-weight: 700;
-}
-
-.cta-card p {
-  margin-top: 0.4rem;
-  color: var(--vp-c-text-2);
-}
+.cta-card a { display: inline-block; font-size: 1.05rem; font-weight: 700; }
+.cta-card p { margin-top: 0.4rem; color: var(--vp-c-text-2); }
 </style>


### PR DESCRIPTION
## Summary

Renews the user-facing docs around the actual differentiator vs Helm / CDK8s / Pulumi: **the same `tsops.config.ts` is imported by both the manifest builder and the application code.** Renaming an app or changing a port becomes a compile error in every caller.

Also kills broken links and modernizes install instructions for the 2026 ecosystem (Bun first-class, yarn removed, Node 20+/22 LTS).

## Changes

### Reframe (README + homepage + "What is tsops?")
- Lead with the runtime-import story; previous copy pitched "typed YAML" which understates what tsops actually does.
- Add a comparison table vs Helm, CDK8s, and Pulumi (the "imported by your app" column is the unique row).
- Replace the generic "YAML is bad → tsops is typed" pitch with the **Kubernetes-first → product-topology-first** inversion.
- Add an honest trade-offs section (opinionated topology, app-layer-only, no state file, runtime requirements).
- Add an "agent-safe" note — tribal knowledge can't be transferred to an LLM, a typed contract can.

### Broken links / placeholders
- Prune sidebar entries that pointed at non-existent pages (`configuration`, `networking`, `building`, `secret-validation`, `multi-environment`, `monorepo`, `cicd`, `api/define-config`, `api/context-helpers`, `api/cli`, `guide/contributing`).
- Surface the existing `Preview Overlays` page in its place.
- Replace `/guide/contributing` link with the real `CONTRIBUTING.md` on GitHub.
- Replace `yourusername.github.io` and `ghcr.io/yourorg` placeholders with `pom4h.github.io` / `ghcr.io/example`.
- Replace fictional `tsops-examples` repo reference in `docs/examples/index.md` with the real `examples/` directory in this repo.

### 2026 / Bun
- Promote Bun to first-class install option alongside pnpm.
- Drop yarn from install groups (effectively dead in 2026).
- Bump prerequisites to **Node.js 20+/22 LTS or Bun 1.1+** (Node 18 EOL'd April 2025).

## Files touched

- `README.md`
- `docs/index.md`
- `docs/README.md`
- `docs/.vitepress/config.ts` (sidebar prune)
- `docs/guide/what-is-tsops.md`
- `docs/guide/getting-started.md`
- `docs/guide/quick-start.md`
- `docs/examples/index.md`

## Out of scope

- The `engines: { node: ">=18.0.0" }` field in published packages is stale but bumping it is a runtime change, not a docs change. Filed as a separate concern.
- New guide pages for the pruned topics (`configuration`, `networking`, etc.) — those should be written from scratch when there's content for them, not stubbed to satisfy a sidebar.

## Test plan

- [ ] `pnpm docs:dev` — sidebar navigates without 404s
- [ ] `pnpm docs:build` — VitePress build succeeds with no dead-link warnings (project already has `ignoreDeadLinks: true` so this is best-effort)
- [ ] Skim README rendering on GitHub


---
_Generated by [Claude Code](https://claude.ai/code/session_01CceKbiRDX8RVrNcHiZL1Fj)_