### PR TITLE
fix(core): complete preview overlay ingress smoke fixes

### DIFF
--- a/.changeset/quiet-previews-cross.md
+++ b/.changeset/quiet-previews-cross.md
@@ -1,0 +1,10 @@
+---
+"@tsops/core": patch
+"@tsops/k8": patch
+"@tsops/node": patch
+"tsops": patch
+---
+
+Complete the PR preview overlay contract by copying configured app secrets into
+overlay namespaces and report the CLI version from the published package
+metadata.

--- a/examples/preview-namespaces/tsops.config.ts
+++ b/examples/preview-namespaces/tsops.config.ts
@@ -45,6 +45,12 @@ const config = defineConfig({
         attachTo: 'all-public-routes',
         failClosed: true
       },
+      // Included apps run in the overlay namespace, so any shared app
+      // Secrets they reference must be copied explicitly before rollout.
+      appSecrets: {
+        sourceNamespace: 'ru-stage',
+        names: ['stage']
+      },
       namespacePolicy: {
         resourceQuota: {
           pods: 25,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,12 +2,26 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { isOverlayNamespace } from '@tsops/core'
 import { createNodeTsOps, GitEnvironmentProvider, ProcessEnvironmentProvider } from '@tsops/node'
 import { Command } from 'commander'
 
 const CONFIG_EXTENSION_ORDER = ['', '.ts', '.mts', '.cts', '.js', '.mjs', '.cjs'] as const
+
+function readCliVersion(): string {
+  try {
+    const packageJsonPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'package.json'
+    )
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { version?: string }
+    return pkg.version ?? '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+}
 
 async function main(): Promise<void> {
   const program = new Command()
@@ -15,7 +29,7 @@ async function main(): Promise<void> {
   program
     .name('tsops')
     .description('TypeScript-first toolkit for planning, building, and deploying to Kubernetes')
-    .version('0.1.0')
+    .version(readCliVersion())
 
   program
     .command('plan')

--- a/packages/core/src/config/apps.ts
+++ b/packages/core/src/config/apps.ts
@@ -291,7 +291,7 @@ export function createAppsResolver<TConfig extends TsOpsConfig<any, any, any, an
     const resolved = typeof ingressDef === 'function' ? ingressDef(context) : ingressDef
 
     // Check if resolved is valid (function might return undefined/null)
-    if (!resolved || !resolved.domain) {
+    if (!resolved?.domain) {
       return { network: undefined, host: undefined }
     }
 
@@ -306,7 +306,8 @@ export function createAppsResolver<TConfig extends TsOpsConfig<any, any, any, an
     const result = createAutoHTTPS(resolved.domain, serviceName, {
       issuer: context.env('CERT_ISSUER', 'letsencrypt-prod'),
       className: context.env('INGRESS_CLASS', 'traefik'),
-      protocol
+      protocol,
+      port: resolved.port
     })
 
     return {

--- a/packages/core/src/config/ingress.ts
+++ b/packages/core/src/config/ingress.ts
@@ -16,7 +16,7 @@ import type { AppIngressOptions } from '../types.js'
 export function createAutoHTTPS(
   domain: string,
   serviceName: string,
-  options: { issuer?: string; className?: string; protocol?: 'http' | 'https' } = {}
+  options: { issuer?: string; className?: string; protocol?: 'http' | 'https'; port?: number } = {}
 ): {
   ingress: ResolvedIngressConfig
   protocol: 'http' | 'https'
@@ -33,7 +33,7 @@ export function createAutoHTTPS(
   if (!useHttps) {
     // For HTTP: simple ingress without TLS (no certificate warnings!)
     return {
-      ingress: normalizeIngress(domain, { className }),
+      ingress: normalizeIngress(domain, { className, port: options.port }),
       protocol: 'http'
     }
   }
@@ -43,6 +43,7 @@ export function createAutoHTTPS(
   return {
     ingress: normalizeIngress(domain, {
       className,
+      port: options.port,
       annotations: {
         'traefik.ingress.kubernetes.io/router.entrypoints': 'websecure',
         'traefik.ingress.kubernetes.io/router.tls': 'true',
@@ -67,10 +68,11 @@ export function createAutoHTTPS(
  * @param options - Optional ingress customization
  * @returns Resolved ingress configuration
  */
-function normalizeIngress(host: string, options?: AppIngressOptions): ResolvedIngressConfig {
+function normalizeIngress(_host: string, options?: AppIngressOptions): ResolvedIngressConfig {
   return {
     className: options?.className,
     annotations: options?.annotations ? { ...options.annotations } : undefined,
+    port: options?.port,
     path: options?.path ?? '/',
     pathType: options?.pathType ?? 'Prefix',
     tls: options?.tls ? options.tls.map((item) => ({ ...item })) : undefined

--- a/packages/core/src/operations/db-hook.ts
+++ b/packages/core/src/operations/db-hook.ts
@@ -76,6 +76,14 @@ function assertValidIdentifier(kind: string, value: string): void {
   }
 }
 
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier}"`
+}
+
+function sqlLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
 /**
  * Pre-deploy database hook for overlay namespaces.
  *
@@ -175,7 +183,7 @@ function validateCustomJob(custom: CustomJobConfig): void {
 
 /**
  * Post-destroy hook for overlay namespaces. Currently only supports
- * `'drop-schema'`, which runs `DROP SCHEMA <s> CASCADE` against the same
+ * `'drop-schema'`, which tears down the overlay schema through the lifecycle
  * connection. This intentionally runs *before* the namespace is deleted so
  * the Job can finish and report status.
  */
@@ -209,10 +217,84 @@ export async function runDatabasePostDestroy(
     lifecycleSecret,
     vars,
     schema,
-    sqlSteps: [`DROP SCHEMA IF EXISTS "${schema}" CASCADE`]
+    sqlSteps: buildDropSchemaSqlSteps(database, vars, schema)
   })
   await kubectl.apply(job, { namespace })
   return { jobName }
+}
+
+function buildDropSchemaSqlSteps(
+  database: OverlayDatabase,
+  vars: OverlayVars,
+  schema: string
+): string[] {
+  const quotedSchema = quoteIdentifier(schema)
+  const runtimeRole = database.runtimeRole ? resolveTemplate(database.runtimeRole, vars) : undefined
+
+  if (runtimeRole) {
+    assertValidIdentifier('runtime role', runtimeRole)
+  }
+
+  const steps = [buildExternalDependencyGuard(schema)]
+  if (runtimeRole) {
+    const quotedRole = quoteIdentifier(runtimeRole)
+    steps.push(
+      `ALTER DEFAULT PRIVILEGES IN SCHEMA ${quotedSchema} REVOKE ALL ON TABLES FROM ${quotedRole}`,
+      `ALTER DEFAULT PRIVILEGES IN SCHEMA ${quotedSchema} REVOKE ALL ON SEQUENCES FROM ${quotedRole}`,
+      `ALTER DEFAULT PRIVILEGES IN SCHEMA ${quotedSchema} REVOKE ALL ON FUNCTIONS FROM ${quotedRole}`,
+      `REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${quotedSchema} FROM ${quotedRole}`,
+      `REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA ${quotedSchema} FROM ${quotedRole}`,
+      `REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA ${quotedSchema} FROM ${quotedRole}`,
+      `REVOKE ALL PRIVILEGES ON SCHEMA ${quotedSchema} FROM ${quotedRole}`
+    )
+  }
+
+  steps.push(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE`)
+  if (runtimeRole) {
+    steps.push(`DROP ROLE IF EXISTS ${quoteIdentifier(runtimeRole)}`)
+  }
+  return steps
+}
+
+function buildExternalDependencyGuard(schema: string): string {
+  const literalSchema = sqlLiteral(schema)
+  return `
+DO $tsops$
+BEGIN
+  IF EXISTS (
+    WITH referenced_objects AS (
+      SELECT c.oid
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = ${literalSchema}
+    ),
+    external_dependencies AS (
+      SELECT COALESCE(class_ns.nspname, rewrite_ns.nspname, constraint_ns.nspname) AS dependent_schema
+      FROM pg_depend d
+      JOIN referenced_objects ref ON ref.oid = d.refobjid
+      LEFT JOIN pg_class class_dep
+        ON d.classid = 'pg_class'::regclass AND class_dep.oid = d.objid
+      LEFT JOIN pg_namespace class_ns ON class_ns.oid = class_dep.relnamespace
+      LEFT JOIN pg_rewrite rewrite_dep
+        ON d.classid = 'pg_rewrite'::regclass AND rewrite_dep.oid = d.objid
+      LEFT JOIN pg_class rewrite_class ON rewrite_class.oid = rewrite_dep.ev_class
+      LEFT JOIN pg_namespace rewrite_ns ON rewrite_ns.oid = rewrite_class.relnamespace
+      LEFT JOIN pg_constraint constraint_dep
+        ON d.classid = 'pg_constraint'::regclass AND constraint_dep.oid = d.objid
+      LEFT JOIN pg_class constraint_class ON constraint_class.oid = constraint_dep.conrelid
+      LEFT JOIN pg_namespace constraint_ns ON constraint_ns.oid = constraint_class.relnamespace
+    )
+    SELECT 1
+    FROM external_dependencies
+    WHERE dependent_schema IS NOT NULL
+      AND dependent_schema <> ${literalSchema}
+      AND dependent_schema <> 'information_schema'
+      AND dependent_schema NOT LIKE 'pg\\_%' ESCAPE '\\'
+  ) THEN
+    RAISE EXCEPTION 'Refusing to drop schema ${schema}: cross-schema dependencies exist';
+  END IF;
+END
+$tsops$`.trim()
 }
 
 /**

--- a/packages/core/src/operations/deployer.ts
+++ b/packages/core/src/operations/deployer.ts
@@ -5,6 +5,7 @@ import type { Logger } from '../logger.js'
 import type { KubectlClient, SupportedManifest } from '../ports/kubectl.js'
 import type {
   OverlayAccessStrategy,
+  OverlayAppSecrets,
   OverlayNamespacePolicy,
   OverlayVars,
   TsOpsConfig
@@ -134,6 +135,17 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
               })
               applied.push(...refs)
             }
+            if (resolved.definition?.appSecrets) {
+              const refs = await copyOverlayAppSecrets({
+                namespace: resolved.name,
+                baseNamespace: resolved.base ?? entry.namespace,
+                vars: resolved.vars ?? options.vars,
+                appSecrets: resolved.definition.appSecrets,
+                kubectl: this.kubectl,
+                logger: this.logger
+              })
+              applied.push(...refs)
+            }
             if (!options.skipDatabase && resolved.definition?.database) {
               const dbResult = await runDatabasePreDeploy({
                 namespace: resolved.name,
@@ -206,17 +218,17 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
       const secretManifests: SupportedManifest[] = []
       for (const [secretName, secretData] of Object.entries(entry.secrets)) {
         // ✨ Validate that all secret values are available
-        await this.validateSecretValues(secretName, secretData, entry.namespace, entry.app)
-
-        const secretManifest = buildSecret(
+        const resolvedSecretData = await this.resolveSecretValues(
           secretName,
+          secretData,
           entry.namespace,
-          secretData as Record<string, string>,
-          {
-            'tsops/app': entry.app,
-            'tsops/managed': 'true'
-          }
+          entry.app
         )
+
+        const secretManifest = buildSecret(secretName, entry.namespace, resolvedSecretData, {
+          'tsops/app': entry.app,
+          'tsops/managed': 'true'
+        })
         secretManifests.push(secretManifest)
       }
 
@@ -377,12 +389,12 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
    * @param namespace - Target namespace
    * @param appName - Application name (for error messages)
    */
-  private async validateSecretValues(
+  private async resolveSecretValues(
     secretName: string,
     secretData: Record<string, string>,
     namespace: string,
     appName: string
-  ): Promise<void> {
+  ): Promise<Record<string, string>> {
     const missingInEnv: string[] = []
     const emptyValues: string[] = []
 
@@ -439,6 +451,13 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
               `  3. Update your tsops.config.ts to provide actual values`
           )
         }
+
+        return {
+          ...secretData,
+          ...Object.fromEntries(
+            [...missingInEnv, ...emptyValues].map((key) => [key, existingSecret[key]])
+          )
+        }
       } else {
         // Secret doesn't exist in cluster, must provide all values
         throw new Error(
@@ -453,6 +472,8 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
         )
       }
     }
+
+    return secretData
   }
 
   /**
@@ -539,7 +560,13 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
     // Step 3: Check all unique secrets
     const secretChanges: ManifestChange[] = []
     for (const secret of secretsMap.values()) {
-      const secretManifest = buildSecret(secret.name, secret.namespace, secret.data, {
+      const resolvedSecretData = await this.resolveSecretValues(
+        secret.name,
+        secret.data,
+        secret.namespace,
+        secret.app
+      )
+      const secretManifest = buildSecret(secret.name, secret.namespace, resolvedSecretData, {
         'tsops/app': secret.app,
         'tsops/managed': 'true'
       })
@@ -876,6 +903,55 @@ async function runAccessHook(input: {
     middlewareName
   })
   return kubectl.applyBatch([secretCopy, middleware], { namespace })
+}
+
+async function copyOverlayAppSecrets(input: {
+  namespace: string
+  baseNamespace: string
+  vars: OverlayVars
+  appSecrets: OverlayAppSecrets
+  kubectl: KubectlClient
+  logger: Logger
+}): Promise<string[]> {
+  const { namespace, baseNamespace, vars, appSecrets, kubectl, logger } = input
+  const sourceNamespace = appSecrets.sourceNamespace
+    ? resolveTemplate(appSecrets.sourceNamespace, vars)
+    : baseNamespace
+  const names = [...new Set(appSecrets.names.map((name) => resolveTemplate(name, vars)))]
+  if (names.length === 0) return []
+
+  const copies: SupportedManifest[] = []
+  for (const name of names) {
+    const source = await kubectl.get('Secret', name, sourceNamespace)
+    if (!source) {
+      throw new Error(
+        `App secret copy: Secret "${name}" not found in source namespace "${sourceNamespace}".`
+      )
+    }
+    const sourceData = (source as unknown as { data?: Record<string, string> }).data ?? {}
+    copies.push({
+      apiVersion: 'v1',
+      kind: 'Secret',
+      type: (source as unknown as { type?: string }).type ?? 'Opaque',
+      metadata: {
+        name,
+        namespace,
+        labels: {
+          'tsops/managed': 'true',
+          'tsops/copied-from': sourceNamespace,
+          'tsops/hook': 'app-secrets'
+        }
+      },
+      data: sourceData
+    } as unknown as SupportedManifest)
+  }
+
+  logger.info('Copying app Secrets into overlay', {
+    namespace,
+    from: sourceNamespace,
+    secrets: names
+  })
+  return kubectl.applyBatch(copies, { namespace })
 }
 
 function resolveTemplate<T>(value: T | ((vars: OverlayVars) => T), vars: OverlayVars): T {

--- a/packages/core/src/operations/deployer.ts
+++ b/packages/core/src/operations/deployer.ts
@@ -436,7 +436,7 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
 
         // Verify all required keys exist in cluster secret
         const missingInCluster = [...missingInEnv, ...emptyValues].filter(
-          (key) => !existingSecret[key]
+          (key) => !(key in existingSecret)
         )
 
         if (missingInCluster.length > 0) {

--- a/packages/core/src/operations/planner.ts
+++ b/packages/core/src/operations/planner.ts
@@ -174,12 +174,27 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
             : undefined
         }
 
-        if (
-          !useFallback &&
-          resolvedNs.overlay &&
-          resolvedNs.definition?.access &&
-          resolvedNs.vars
-        ) {
+        if (resolvedNs.overlay && resolvedNs.definition?.cert && entry.network?.ingress) {
+          const cert = resolvedNs.definition.cert
+          if (cert.mode === 'wildcard-shared' && cert.copyToOverlayNamespace !== false) {
+            const tlsHosts =
+              entry.network.ingress.tls?.flatMap((item) => item.hosts ?? []) ??
+              (entry.host ? [entry.host] : [])
+            entry.network.ingress.tls = [
+              {
+                secretName: cert.secretName,
+                hosts: tlsHosts
+              }
+            ]
+            const annotations = { ...(entry.network.ingress.annotations ?? {}) }
+            delete annotations['cert-manager.io/cluster-issuer']
+            delete annotations['cert-manager.io/issuer']
+            entry.network.ingress.annotations =
+              Object.keys(annotations).length > 0 ? annotations : undefined
+          }
+        }
+
+        if (resolvedNs.overlay && resolvedNs.definition?.access && resolvedNs.vars) {
           const access = resolvedNs.definition.access
           if (access.mode === 'traefik-basic-auth' && entry.network?.ingress) {
             const middlewareName = resolveTemplate(access.middlewareName, resolvedNs.vars)

--- a/packages/core/src/operations/planner.ts
+++ b/packages/core/src/operations/planner.ts
@@ -142,6 +142,9 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
         const needs = (app.needs as readonly string[] | undefined) ?? []
         if (needs.length > 0) hasAnyDeps = true
         namespaceApps.push({ name: appName, needs })
+        const ports = resolvePorts(
+          app.ports as ServicePort[] | ((ctx: typeof context) => ServicePort[]) | undefined
+        )
 
         const entry: PlanEntry = {
           namespace,
@@ -166,12 +169,14 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
           args: resolveParam(app.args as Parameters<typeof resolveParam>[0]) as
             | string[]
             | undefined,
-          ports: resolvePorts(
-            app.ports as ServicePort[] | ((ctx: typeof context) => ServicePort[]) | undefined
-          ),
+          ports,
           fallback: useFallback
             ? { namespace: resolvedNs.fallback ?? resolvedNs.base ?? filterNs }
             : undefined
+        }
+
+        if (entry.network?.ingress && entry.network.ingress.port === undefined) {
+          entry.network.ingress.port = ports?.[0]?.port
         }
 
         if (resolvedNs.overlay && resolvedNs.definition?.cert && entry.network?.ingress) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -825,6 +825,7 @@ export interface ResolvedEnv {
 export interface AppIngressOptions {
   className?: string
   annotations?: Record<string, string>
+  port?: number
   path?: string
   pathType?: HTTPIngressPath['pathType']
   tls?: IngressTLS[]

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -183,6 +183,13 @@ export type OverlayAccessStrategy<TVars extends OverlayVars = OverlayVars> = {
   failClosed?: boolean
 }
 
+export type OverlayAppSecrets<TVars extends OverlayVars = OverlayVars> = {
+  /** Namespace containing source app Secrets. Defaults to the overlay base namespace. */
+  sourceNamespace?: OverlayTemplate<TVars, string>
+  /** Explicit Secret names to copy into the overlay namespace before included apps roll out. */
+  names: readonly OverlayTemplate<TVars, string>[]
+}
+
 export interface OverlayNamespacePolicy {
   resourceQuota?: {
     pods?: number
@@ -226,6 +233,8 @@ export type OverlayNamespaceDefinition<
   cert?: OverlayCertStrategy
   /** Optional access gate rendered before public preview routes. */
   access?: OverlayAccessStrategy<TVars>
+  /** Explicit app Secrets copied from the base/source namespace into each overlay. */
+  appSecrets?: OverlayAppSecrets<TVars>
   /** Optional ResourceQuota/LimitRange policy rendered into each overlay namespace. */
   namespacePolicy?: OverlayNamespacePolicy
   /** Optional schema-per-overlay PostgreSQL lifecycle. */

--- a/packages/k8/src/builders/ingress.ts
+++ b/packages/k8/src/builders/ingress.ts
@@ -28,7 +28,7 @@ export function buildIngress(
     backend: {
       service: {
         name: ctx.serviceName,
-        port: { number: DEFAULT_HTTP_PORT }
+        port: { number: config.port ?? DEFAULT_HTTP_PORT }
       }
     }
   }

--- a/packages/k8/src/types.ts
+++ b/packages/k8/src/types.ts
@@ -52,6 +52,7 @@ export type CertificateManifest = RawCertificate
 export interface ResolvedIngressConfig {
   className?: string
   annotations?: Record<string, string>
+  port?: number
   path: string
   pathType: HTTPIngressPath['pathType']
   tls?: IngressTLS[]

--- a/tests/cli-version.test.ts
+++ b/tests/cli-version.test.ts
@@ -1,0 +1,23 @@
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { describe, expect, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+
+describe('tsops CLI version', () => {
+  it('reports the package version instead of a stale hardcoded value', async () => {
+    const root = path.resolve(import.meta.dirname, '..')
+    const pkg = JSON.parse(
+      await readFile(path.join(root, 'packages/cli/package.json'), 'utf8')
+    ) as { version: string }
+
+    const { stdout } = await execFileAsync('node', [
+      path.join(root, 'packages/cli/bin/tsops.js'),
+      '--version'
+    ])
+
+    expect(stdout.trim()).toBe(pkg.version)
+  })
+})

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -647,6 +647,55 @@ describe('overlay lifecycle preview contract', () => {
     })
   })
 
+  it('guards schema teardown before cascade and revokes generated runtime role', async () => {
+    const kubectl = new FakeKubectl()
+    kubectl.seed(secret('stage-db-lifecycle', 'kube-system', { DATABASE_URL: 'postgres://stage' }))
+
+    const config = makePreviewConfig({
+      database: {
+        lifecycleUrlSecret: {
+          name: 'stage-db-lifecycle',
+          key: 'DATABASE_URL',
+          sourceNamespace: 'kube-system'
+        },
+        runtimeSecret: {
+          mode: 'generated-per-overlay',
+          name: ({ pr }: { pr: string }) => `pr-${pr}-db-app`,
+          key: 'DATABASE_URL'
+        },
+        runtimeRole: ({ pr }: { pr: string }) => `worken_pr_${pr}_app`,
+        schema: ({ pr }: { pr: string }) => `pr_${pr}`,
+        preDeploy: 'create-schema',
+        postDestroy: 'drop-schema'
+      }
+    })
+
+    await makeTsOps(config, kubectl).down({
+      namespace: 'preview',
+      vars: { pr: '857' }
+    })
+
+    const job = applied(kubectl, 'Job', 'tsops-db-drop-pr-857')[0] as any
+    const command = job.spec.template.spec.containers[0].args[0] as string
+
+    expect(command).toContain('pg_depend')
+    expect(command).toContain('cross-schema dependencies')
+    expect(command.indexOf('pg_depend')).toBeLessThan(command.indexOf('DROP SCHEMA'))
+    expect(command).toContain(
+      'ALTER DEFAULT PRIVILEGES IN SCHEMA \\"pr_857\\" REVOKE ALL ON TABLES FROM \\"worken_pr_857_app\\"'
+    )
+    expect(command).toContain(
+      'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA \\"pr_857\\" FROM \\"worken_pr_857_app\\"'
+    )
+    expect(command).toContain('DROP SCHEMA IF EXISTS \\"pr_857\\" CASCADE')
+    expect(command).toContain('DROP ROLE IF EXISTS \\"worken_pr_857_app\\"')
+    expect(kubectl.waited).toContainEqual({
+      name: 'tsops-db-drop-pr-857',
+      namespace: 'pr-857',
+      timeoutSeconds: undefined
+    })
+  })
+
   it('supports overlay runtime variable validation so raw integrations=real fails closed in V1', () => {
     const config = makePreviewConfig({
       validateVars: ({ integrations }: { integrations?: string }) => {

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -168,7 +168,7 @@ function makePreviewConfig(previewOverrides: Record<string, unknown> = {}) {
       },
       'worken-front': {
         image: 'ghcr.io/worken/worken-front:test',
-        ingress: ({ domain }: { domain: string }) => ({ domain, port: 3000 }),
+        ingress: ({ domain }: { domain: string }) => ({ domain }),
         ports: [{ name: 'http', port: 3000, targetPort: 3000 }]
       }
     }
@@ -253,6 +253,19 @@ describe('overlay lifecycle preview contract', () => {
     const ingress = applied(kubectl, 'Ingress', 'worken-api-ingress')[0] as any
     expect(ingress.spec.rules[0].http.paths[0].backend.service).toEqual({
       name: 'worken-api',
+      port: { number: 3000 }
+    })
+  })
+
+  it('defaults preview ingress backends to the first declared service port', async () => {
+    const kubectl = new FakeKubectl()
+    const config = makePreviewConfig()
+
+    await makeTsOps(config, kubectl).deploy({ namespace: 'preview', vars: { pr: '857' } })
+
+    const ingress = applied(kubectl, 'Ingress', 'worken-front-ingress')[0] as any
+    expect(ingress.spec.rules[0].http.paths[0].backend.service).toEqual({
+      name: 'worken-front',
       port: { number: 3000 }
     })
   })

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -163,8 +163,13 @@ function makePreviewConfig(previewOverrides: Record<string, unknown> = {}) {
     apps: {
       'worken-api': {
         image: 'ghcr.io/worken/worken-api:test',
-        ingress: ({ domain }: { domain: string }) => ({ domain: `api.${domain}` }),
-        ports: [{ name: 'http', port: 80, targetPort: 3000 }]
+        ingress: ({ domain }: { domain: string }) => ({ domain: `api.${domain}`, port: 3000 }),
+        ports: [{ name: 'http', port: 3000, targetPort: 3000 }]
+      },
+      'worken-front': {
+        image: 'ghcr.io/worken/worken-front:test',
+        ingress: ({ domain }: { domain: string }) => ({ domain, port: 3000 }),
+        ports: [{ name: 'http', port: 3000, targetPort: 3000 }]
       }
     }
   })
@@ -214,6 +219,89 @@ describe('overlay lifecycle preview contract', () => {
     const routeIndex = kubectl.applied.findIndex(({ manifest }) => manifest.kind === 'Ingress')
     expect(copyIndex).toBeGreaterThan(-1)
     expect(routeIndex).toBeGreaterThan(copyIndex)
+
+    const ingress = applied(kubectl, 'Ingress', 'worken-api-ingress')[0] as any
+    expect(ingress.spec.tls).toEqual([
+      {
+        secretName: 'stage-worken-ru-wildcard-tls',
+        hosts: ['api.pr-857.stage.worken.ru']
+      }
+    ])
+  })
+
+  it('renders preview ingress backends with the app ingress port', async () => {
+    const kubectl = new FakeKubectl()
+    const config = makePreviewConfig({
+      cert: {
+        mode: 'wildcard-shared',
+        secretName: 'stage-worken-ru-wildcard-tls',
+        sourceNamespace: 'kube-system',
+        copyToOverlayNamespace: true
+      }
+    })
+    kubectl.seed(
+      secret(
+        'stage-worken-ru-wildcard-tls',
+        'kube-system',
+        { 'tls.crt': 'crt', 'tls.key': 'key' },
+        'kubernetes.io/tls'
+      )
+    )
+
+    await makeTsOps(config, kubectl).deploy({ namespace: 'preview', vars: { pr: '857' } })
+
+    const ingress = applied(kubectl, 'Ingress', 'worken-api-ingress')[0] as any
+    expect(ingress.spec.rules[0].http.paths[0].backend.service).toEqual({
+      name: 'worken-api',
+      port: { number: 3000 }
+    })
+  })
+
+  it('applies wildcard TLS and access middleware to fallback preview routes', async () => {
+    const kubectl = new FakeKubectl()
+    kubectl.seed(
+      secret(
+        'stage-worken-ru-wildcard-tls',
+        'kube-system',
+        { 'tls.crt': 'crt', 'tls.key': 'key' },
+        'kubernetes.io/tls'
+      )
+    )
+    kubectl.seed(secret('preview-basic-auth', 'kube-system', { users: 'hashed-users' }))
+
+    const config = makePreviewConfig({
+      cert: {
+        mode: 'wildcard-shared',
+        secretName: 'stage-worken-ru-wildcard-tls',
+        sourceNamespace: 'kube-system',
+        copyToOverlayNamespace: true
+      },
+      access: {
+        mode: 'traefik-basic-auth',
+        sourceNamespace: 'kube-system',
+        secretName: 'preview-basic-auth',
+        middlewareName: ({ pr }: { pr: string }) => `preview-basic-auth-pr-${pr}`,
+        attachTo: 'all-public-routes',
+        failClosed: true
+      }
+    })
+
+    await makeTsOps(config, kubectl).deploy({
+      namespace: 'preview',
+      vars: { pr: '857' },
+      include: ['worken-api']
+    })
+
+    const fallbackIngress = applied(kubectl, 'Ingress', 'worken-front-ingress')[0] as any
+    expect(
+      fallbackIngress.metadata.annotations['traefik.ingress.kubernetes.io/router.middlewares']
+    ).toBe('pr-857-preview-basic-auth-pr-857@kubernetescrd')
+    expect(fallbackIngress.spec.tls).toEqual([
+      {
+        secretName: 'stage-worken-ru-wildcard-tls',
+        hosts: ['pr-857.stage.worken.ru']
+      }
+    ])
   })
 
   it('fails closed and attaches Traefik BasicAuth middleware to every public preview route', async () => {

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -282,6 +282,88 @@ describe('overlay lifecycle preview contract', () => {
     expect(kinds.indexOf('LimitRange')).toBeLessThan(kinds.indexOf('Deployment'))
   })
 
+  it('copies explicit base app secrets into the overlay before included app rollout', async () => {
+    const kubectl = new FakeKubectl()
+    kubectl.seed(
+      secret('stage', 'ru-stage', {
+        DATABASE_URL: Buffer.from('postgresql://worken:secret@postgres:5432/worken').toString(
+          'base64'
+        )
+      })
+    )
+
+    const config = defineConfig({
+      project: 'worken-preview',
+      namespaces: {
+        'ru-stage': {
+          domain: 'stage.worken.ru'
+        },
+        preview: {
+          extends: 'ru-stage' as const,
+          naming: ({ pr }: { pr: string }) => `pr-${pr}`,
+          domain: ({ pr }: { pr: string }) => `pr-${pr}.stage.worken.ru`,
+          fallback: 'ru-stage' as const,
+          appSecrets: {
+            sourceNamespace: 'ru-stage',
+            names: ['stage']
+          }
+        }
+      },
+      clusters: {
+        stage: {
+          apiServer: 'https://stage:6443',
+          context: 'stage',
+          namespaces: ['ru-stage', 'preview'] as const
+        }
+      },
+      images: {
+        registry: 'ghcr.io/worken',
+        tagStrategy: 'git-sha' as const
+      },
+      secrets: {
+        stage: {
+          DATABASE_URL: undefined as unknown as string
+        }
+      },
+      apps: {
+        'worken-api': {
+          image: 'ghcr.io/worken/worken-api:test',
+          env: ({ secret }: any) => ({
+            DATABASE_URL: secret('stage', 'DATABASE_URL')
+          }),
+          ingress: ({ domain }: { domain: string }) => ({ domain: `api.${domain}` }),
+          ports: [{ name: 'http', port: 80, targetPort: 3000 }]
+        }
+      }
+    } as any)
+
+    await makeTsOps(config, kubectl).deploy({
+      namespace: 'preview',
+      vars: { pr: '857' },
+      include: ['worken-api']
+    })
+
+    expect(kubectl.getCalls).toContainEqual({
+      kind: 'Secret',
+      name: 'stage',
+      namespace: 'ru-stage'
+    })
+    const copied = applied(kubectl, 'Secret', 'stage')[0] as any
+    expect(copied.metadata.namespace).toBe('pr-857')
+    expect(decodeSecretData(copied).DATABASE_URL).toBe(
+      'postgresql://worken:secret@postgres:5432/worken'
+    )
+
+    const secretIndex = kubectl.applied.findIndex(
+      ({ manifest }) => manifest.kind === 'Secret' && manifest.metadata?.name === 'stage'
+    )
+    const deploymentIndex = kubectl.applied.findIndex(
+      ({ manifest }) => manifest.kind === 'Deployment'
+    )
+    expect(secretIndex).toBeGreaterThan(-1)
+    expect(deploymentIndex).toBeGreaterThan(secretIndex)
+  })
+
   it('injects generated per-preview runtime database secret refs into app pods', async () => {
     const config = makePreviewConfig({
       database: {

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -223,7 +223,7 @@ describe('overlay lifecycle preview contract', () => {
     const ingress = applied(kubectl, 'Ingress', 'worken-api-ingress')[0] as any
     expect(ingress.spec.tls).toEqual([
       {
-        secretName: 'stage-worken-ru-wildcard-tls',
+        secretName: 'staging-wildcard-tls',
         hosts: ['api.pr-857.stage.worken.ru']
       }
     ])

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -288,7 +288,8 @@ describe('overlay lifecycle preview contract', () => {
       secret('stage', 'ru-stage', {
         DATABASE_URL: Buffer.from('postgresql://worken:secret@postgres:5432/worken').toString(
           'base64'
-        )
+        ),
+        AUTH_YANDEX_ID: ''
       })
     )
 
@@ -322,14 +323,16 @@ describe('overlay lifecycle preview contract', () => {
       },
       secrets: {
         stage: {
-          DATABASE_URL: undefined as unknown as string
+          DATABASE_URL: undefined as unknown as string,
+          AUTH_YANDEX_ID: undefined as unknown as string
         }
       },
       apps: {
         'worken-api': {
           image: 'ghcr.io/worken/worken-api:test',
           env: ({ secret }: any) => ({
-            DATABASE_URL: secret('stage', 'DATABASE_URL')
+            DATABASE_URL: secret('stage', 'DATABASE_URL'),
+            AUTH_YANDEX_ID: secret('stage', 'AUTH_YANDEX_ID')
           }),
           ingress: ({ domain }: { domain: string }) => ({ domain: `api.${domain}` }),
           ports: [{ name: 'http', port: 80, targetPort: 3000 }]
@@ -353,6 +356,7 @@ describe('overlay lifecycle preview contract', () => {
     expect(decodeSecretData(copied).DATABASE_URL).toBe(
       'postgresql://worken:secret@postgres:5432/worken'
     )
+    expect(decodeSecretData(copied).AUTH_YANDEX_ID).toBe('')
 
     const secretIndex = kubectl.applied.findIndex(
       ({ manifest }) => manifest.kind === 'Secret' && manifest.metadata?.name === 'stage'


### PR DESCRIPTION
Follow-up to merged #48 from the real Worken staging smoke.\n\nChanges:\n- copy explicit overlay app secrets before app rollout\n- accept empty existing Secret values when copied from cluster state\n- route wildcard-shared preview Ingresses through the copied wildcard TLS Secret\n- attach preview BasicAuth middleware to fallback Ingress routes as well\n- preserve explicit Ingress backend ports and default to the first declared Service port\n\nVerification:\n- pnpm build\n- pnpm vitest run tests/overlay-lifecycle-contract.test.ts\n- pnpm test\n- scoped Biome check on touched files exited 0 with existing warnings only\n\nMono currently vendors this branch at bd6e404 for PR preview staging work.