### PR TITLE
fix(core): escape drop-schema SQL for shell

### DIFF
--- a/.changeset/fuzzy-drops-run.md
+++ b/.changeset/fuzzy-drops-run.md
@@ -1,0 +1,7 @@
+---
+"@tsops/core": patch
+"tsops": patch
+---
+
+Escape shell-sensitive SQL in built-in PostgreSQL drop-schema jobs so dollar-quoted
+guards run correctly through `/bin/sh -c`.

--- a/packages/core/src/operations/db-hook.ts
+++ b/packages/core/src/operations/db-hook.ts
@@ -457,7 +457,7 @@ function renderPsqlJob(input: {
   sqlSteps: string[]
 }): SupportedManifest {
   const { namespace, name, database, lifecycleSecret, vars, schema, sqlSteps } = input
-  const sql = sqlSteps.map((s) => s.replace(/"/g, '\\"')).join('; ')
+  const sql = shellDoubleQuoted(sqlSteps.join('; '))
 
   const job = {
     apiVersion: 'batch/v1',
@@ -500,6 +500,14 @@ function renderPsqlJob(input: {
   }
 
   return job as unknown as SupportedManifest
+}
+
+function shellDoubleQuoted(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, '\\$')
+    .replace(/`/g, '\\`')
 }
 
 function renderCustomJob(

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -680,6 +680,8 @@ describe('overlay lifecycle preview contract', () => {
 
     expect(command).toContain('pg_depend')
     expect(command).toContain('cross-schema dependencies')
+    expect(command).toContain('DO \\$tsops\\$')
+    expect(command).not.toContain('DO $tsops$')
     expect(command.indexOf('pg_depend')).toBeLessThan(command.indexOf('DROP SCHEMA'))
     expect(command).toContain(
       'ALTER DEFAULT PRIVILEGES IN SCHEMA \\"pr_857\\" REVOKE ALL ON TABLES FROM \\"worken_pr_857_app\\"'


### PR DESCRIPTION
## Summary\n- Escape shell-sensitive SQL characters in built-in PostgreSQL drop-schema jobs\n- Add a contract assertion that the dollar-quoted dependency guard survives /bin/sh -c\n- Add a patch changeset for core/cli release\n\n## Verification\n- pnpm exec biome check packages/core/src/operations/db-hook.ts tests/overlay-lifecycle-contract.test.ts .changeset/fuzzy-drops-run.md\n- pnpm build\n- pnpm test\n\n## Context\nReal Worken preview teardown on the staging cluster produced `DO $` because /bin/sh expanded `` inside the generated `psql -c` command. This patch preserves `DO \\$` through the shell.