### PR TITLE
fix(core): allow drop-schema without runtime secret

### DIFF
--- a/.changeset/breezy-runtime-drops.md
+++ b/.changeset/breezy-runtime-drops.md
@@ -1,0 +1,7 @@
+---
+"@tsops/core": patch
+"tsops": patch
+---
+
+Do not require generated runtime database Secrets for built-in drop-schema jobs;
+the drop SQL only needs lifecycle credentials and resolved metadata.

--- a/packages/core/src/operations/db-hook.ts
+++ b/packages/core/src/operations/db-hook.ts
@@ -217,7 +217,8 @@ export async function runDatabasePostDestroy(
     lifecycleSecret,
     vars,
     schema,
-    sqlSteps: buildDropSchemaSqlSteps(database, vars, schema)
+    sqlSteps: buildDropSchemaSqlSteps(database, vars, schema),
+    includeRuntimeSecretEnv: false
   })
   await kubectl.apply(job, { namespace })
   return { jobName }
@@ -455,8 +456,18 @@ function renderPsqlJob(input: {
   vars: OverlayVars
   schema: string
   sqlSteps: string[]
+  includeRuntimeSecretEnv?: boolean
 }): SupportedManifest {
-  const { namespace, name, database, lifecycleSecret, vars, schema, sqlSteps } = input
+  const {
+    namespace,
+    name,
+    database,
+    lifecycleSecret,
+    vars,
+    schema,
+    sqlSteps,
+    includeRuntimeSecretEnv = true
+  } = input
   const sql = shellDoubleQuoted(sqlSteps.join('; '))
 
   const job = {
@@ -490,7 +501,7 @@ function renderPsqlJob(input: {
                   }
                 },
                 ...renderDatabaseMetadataEnv(database, vars, schema),
-                ...renderRuntimeSecretEnv(database, vars)
+                ...(includeRuntimeSecretEnv ? renderRuntimeSecretEnv(database, vars) : [])
               ]
             }
           ]

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -677,6 +677,12 @@ describe('overlay lifecycle preview contract', () => {
 
     const job = applied(kubectl, 'Job', 'tsops-db-drop-pr-857')[0] as any
     const command = job.spec.template.spec.containers[0].args[0] as string
+    const env = Object.fromEntries(
+      job.spec.template.spec.containers[0].env.map((item: any) => [
+        item.name,
+        item.value ?? item.valueFrom
+      ])
+    )
 
     expect(command).toContain('pg_depend')
     expect(command).toContain('cross-schema dependencies')
@@ -691,6 +697,10 @@ describe('overlay lifecycle preview contract', () => {
     )
     expect(command).toContain('DROP SCHEMA IF EXISTS \\"pr_857\\" CASCADE')
     expect(command).toContain('DROP ROLE IF EXISTS \\"worken_pr_857_app\\"')
+    expect(env.DATABASE_RUNTIME_ROLE).toBe('worken_pr_857_app')
+    expect(env.DATABASE_RUNTIME_SECRET_NAME).toBe('pr-857-db-app')
+    expect(env.DATABASE_RUNTIME_URL).toBeUndefined()
+    expect(env.DATABASE_RUNTIME_PASSWORD).toBeUndefined()
     expect(kubectl.waited).toContainEqual({
       name: 'tsops-db-drop-pr-857',
       namespace: 'pr-857',


### PR DESCRIPTION
## Summary\n- Do not inject generated runtime database Secret value refs into built-in drop-schema jobs\n- Keep runtime metadata in the job env for observability\n- Add a contract assertion for teardown after --skip-database / missing runtime Secret\n- Add a patch changeset\n\n## Verification\n- pnpm exec biome check packages/core/src/operations/db-hook.ts tests/overlay-lifecycle-contract.test.ts .changeset/breezy-runtime-drops.md\n- pnpm build\n- pnpm test\n\n## Context\nWorken staging smoke validated the 2.0.2 shell escaping fix, then exposed that `tsops down` after `tsops up --skip-database` can leave the drop job in CreateContainerConfigError because the generated runtime DB Secret was intentionally never created. The built-in drop SQL only needs lifecycle credentials and resolved role/schema metadata.