### PR TITLE
fix(core): guard missing runtime role cleanup

### DIFF
--- a/.changeset/calm-schema-drops.md
+++ b/.changeset/calm-schema-drops.md
@@ -1,0 +1,7 @@
+---
+"@tsops/core": patch
+"tsops": patch
+---
+
+Make built-in drop-schema runtime role cleanup idempotent when the resolved
+runtime role was never created.

--- a/packages/core/src/operations/db-hook.ts
+++ b/packages/core/src/operations/db-hook.ts
@@ -238,16 +238,7 @@ function buildDropSchemaSqlSteps(
 
   const steps = [buildExternalDependencyGuard(schema)]
   if (runtimeRole) {
-    const quotedRole = quoteIdentifier(runtimeRole)
-    steps.push(
-      `ALTER DEFAULT PRIVILEGES IN SCHEMA ${quotedSchema} REVOKE ALL ON TABLES FROM ${quotedRole}`,
-      `ALTER DEFAULT PRIVILEGES IN SCHEMA ${quotedSchema} REVOKE ALL ON SEQUENCES FROM ${quotedRole}`,
-      `ALTER DEFAULT PRIVILEGES IN SCHEMA ${quotedSchema} REVOKE ALL ON FUNCTIONS FROM ${quotedRole}`,
-      `REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${quotedSchema} FROM ${quotedRole}`,
-      `REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA ${quotedSchema} FROM ${quotedRole}`,
-      `REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA ${quotedSchema} FROM ${quotedRole}`,
-      `REVOKE ALL PRIVILEGES ON SCHEMA ${quotedSchema} FROM ${quotedRole}`
-    )
+    steps.push(buildRuntimeRoleCleanupGuard(schema, runtimeRole))
   }
 
   steps.push(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE`)
@@ -255,6 +246,30 @@ function buildDropSchemaSqlSteps(
     steps.push(`DROP ROLE IF EXISTS ${quoteIdentifier(runtimeRole)}`)
   }
   return steps
+}
+
+function buildRuntimeRoleCleanupGuard(schema: string, runtimeRole: string): string {
+  const quotedSchema = quoteIdentifier(schema)
+  const quotedRole = quoteIdentifier(runtimeRole)
+  const roleLiteral = sqlLiteral(runtimeRole)
+  const revokeSteps = [
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA ${quotedSchema} REVOKE ALL ON TABLES FROM ${quotedRole}`,
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA ${quotedSchema} REVOKE ALL ON SEQUENCES FROM ${quotedRole}`,
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA ${quotedSchema} REVOKE ALL ON FUNCTIONS FROM ${quotedRole}`,
+    `REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${quotedSchema} FROM ${quotedRole}`,
+    `REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA ${quotedSchema} FROM ${quotedRole}`,
+    `REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA ${quotedSchema} FROM ${quotedRole}`,
+    `REVOKE ALL PRIVILEGES ON SCHEMA ${quotedSchema} FROM ${quotedRole}`
+  ]
+
+  return `
+DO $tsops$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = ${roleLiteral}) THEN
+${revokeSteps.map((step) => `    EXECUTE ${sqlLiteral(step)};`).join('\n')}
+  END IF;
+END
+$tsops$`.trim()
 }
 
 function buildExternalDependencyGuard(schema: string): string {

--- a/tests/overlay-lifecycle-contract.test.ts
+++ b/tests/overlay-lifecycle-contract.test.ts
@@ -686,6 +686,7 @@ describe('overlay lifecycle preview contract', () => {
 
     expect(command).toContain('pg_depend')
     expect(command).toContain('cross-schema dependencies')
+    expect(command).toContain("pg_roles WHERE rolname = 'worken_pr_857_app'")
     expect(command).toContain('DO \\$tsops\\$')
     expect(command).not.toContain('DO $tsops$')
     expect(command.indexOf('pg_depend')).toBeLessThan(command.indexOf('DROP SCHEMA'))


### PR DESCRIPTION
## Summary\n- Wrap built-in drop-schema runtime role cleanup in a pg_roles existence guard\n- Keep DROP ROLE IF EXISTS as the final no-op-safe cleanup\n- Add a contract assertion for the missing-role path\n- Add a patch changeset\n\n## Verification\n- pnpm exec biome check packages/core/src/operations/db-hook.ts tests/overlay-lifecycle-contract.test.ts .changeset/calm-schema-drops.md\n- pnpm build\n- pnpm test\n\n## Context\nWorken staging smoke with tsops@2.0.3 got past shell escaping and missing runtime Secret refs, then failed when the generated runtime role had never been created because the deploy used --skip-database. PostgreSQL errors on REVOKE/ALTER DEFAULT PRIVILEGES FROM a missing role, so built-in drop-schema needs a role existence guard for idempotent teardown.