### PR TITLE
feat: add source-key image reuse

### DIFF
--- a/.changeset/source-key-image-reuse.md
+++ b/.changeset/source-key-image-reuse.md
@@ -1,0 +1,7 @@
+---
+"@tsops/core": minor
+"@tsops/node": minor
+"tsops": minor
+---
+
+Add source-key Docker image reuse, BuildKit registry cache options, and immutable image digest overrides for deploy/up flows.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -307,9 +307,20 @@ interface DockerfileBuild {
   args?: Record<string, string>
   target?: string
   inputs?: readonly string[]
-  sourceKey?: boolean | string | ((ctx: AppBuildContext) => string | Promise<string>)
+  sourceKey?: BuildSourceKeyConfig
   cache?: { type: 'registry'; ref?: string; mode?: 'min' | 'max' }
 }
+
+type BuildSourceKeyConfig =
+  | boolean
+  | string
+  | ((ctx: AppBuildContext) => string | Promise<string>)
+  | { mode?: 'context' }
+  | { mode: 'inputs'; inputs: readonly string[] }
+  | {
+      mode: 'custom'
+      value: string | ((ctx: AppBuildContext) => string | Promise<string>)
+    }
 ```
 
 When `inputs` or `sourceKey` is set, `tsops build` checks for a `source-<hash>`

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -127,6 +127,7 @@ tsops build [options]
 - `-n, --namespace <name>` - Use namespace context (influences env functions)
 - `-c, --config <path>` - Config file path
 - `--dry-run` - Log Docker commands without executing
+- `--source-key` - Reuse Docker images by hashing source inputs and build metadata
 
 ### deploy
 
@@ -141,6 +142,7 @@ tsops deploy [options]
 - `--app <name>` - Target a single app
 - `-c, --config <path>` - Config file path
 - `--dry-run` - Log kubectl actions without executing
+- `--image-digests <json-or-file>` - Override app images with immutable digest refs
 
 ## Context Helpers
 
@@ -291,6 +293,38 @@ interface AppDefinition {
   volumeMounts?: VolumeMount[]
   args?: string[]
 }
+```
+
+`DockerfileBuild` supports content-addressed image reuse:
+
+```typescript
+interface DockerfileBuild {
+  type: 'dockerfile'
+  context: string
+  dockerfile: string
+  platform?: string | ((ctx: AppBuildContext) => string)
+  env?: Record<string, string>
+  args?: Record<string, string>
+  target?: string
+  inputs?: readonly string[]
+  sourceKey?: boolean | string | ((ctx: AppBuildContext) => string | Promise<string>)
+  cache?: { type: 'registry'; ref?: string; mode?: 'min' | 'max' }
+}
+```
+
+When `inputs` or `sourceKey` is set, `tsops build` checks for a `source-<hash>`
+image tag before building. The build result carries the immutable digest ref
+when the Docker adapter can resolve one.
+
+Programmatic deploy calls can pass the same digest handoff used by the CLI:
+
+```typescript
+await tsops.deploy({
+  namespace: 'preview',
+  imageOverrides: {
+    api: 'ghcr.io/acme/api@sha256:abcd...'
+  }
+})
 ```
 
 The `ingress` field uses a simple object format:

--- a/docs/examples/ci-cd/README.md
+++ b/docs/examples/ci-cd/README.md
@@ -155,7 +155,8 @@ env:
    ```
 
 2. **App Matching**
-   - tsops compares changed files with `build.context` in config
+   - tsops compares changed files with `build.inputs` when configured
+   - Apps without `build.inputs` fall back to matching `build.context`
    - Only apps with matching paths are selected
 
 3. **Docker Build**
@@ -240,6 +241,7 @@ manifests.
 
 Using `--filter` in monorepos provides:
 - Build only changed applications
+- Keep broad Docker contexts while narrowing app selection with `build.inputs`
 - Reduce Docker registry bandwidth usage
 - Lower CI compute costs
 - Faster feedback for developers
@@ -251,7 +253,7 @@ Using `--filter` in monorepos provides:
 **Issue:** `--filter HEAD^1` returns "No apps affected by changed files"
 
 **Causes:**
-1. Changes are outside any `build.context` directory
+1. Changes are outside any configured `build.inputs` or `build.context` path
 2. `fetch-depth: 0` missing in checkout action
 3. Comparing against wrong git reference
 
@@ -267,8 +269,9 @@ Using `--filter` in monorepos provides:
 **Issue:** Cache is not working, builds all apps
 
 **Causes:**
-1. `build.context` paths don't match actual file paths
-2. Config changes force rebuild (expected behavior)
+1. `build.inputs` or `build.context` paths don't match actual file paths
+2. Apps intentionally share the same root context without narrower `build.inputs`
+3. Config changes force rebuild (expected behavior)
 
 **Solution:**
 Check your tsops.config.ts:
@@ -276,8 +279,9 @@ Check your tsops.config.ts:
 apps: {
   api: {
     build: {
-      context: './packages/api',  // ← Must match actual path
-      dockerfile: './packages/api/Dockerfile'
+      context: '.',
+      dockerfile: './packages/api/Dockerfile',
+      inputs: ['packages/api/**', 'packages/shared/**']
     }
   }
 }

--- a/docs/examples/ci-cd/README.md
+++ b/docs/examples/ci-cd/README.md
@@ -170,6 +170,53 @@ env:
    # Deploys all apps (or use --app to deploy specific ones)
    ```
 
+### Source-Key Image Reuse
+
+For preview environments, combine `build.inputs` with `tsops build --source-key`
+so CI can skip Docker builds when an equivalent image already exists in the
+registry. The source key hashes the selected input files plus Docker build
+metadata and tags the image as `source-<hash>`.
+
+```typescript
+apps: {
+  api: {
+    build: {
+      type: 'dockerfile',
+      context: '.',
+      dockerfile: 'apps/api/Dockerfile',
+      inputs: ['apps/api/**', 'packages/shared/**', 'package.json', 'pnpm-lock.yaml'],
+      cache: { type: 'registry', mode: 'max' }
+    }
+  }
+}
+```
+
+```bash
+pnpm tsops build --app api --source-key
+```
+
+When `cache: { type: 'registry' }` is set, the Node adapter uses Docker BuildKit
+registry cache flags. If `cache.ref` is omitted, the default cache image is the
+same repository with a `:cache` tag.
+
+### Immutable Preview Handoff
+
+Pass the digest refs produced by CI back into the preview deploy. This keeps the
+deployment tied to the exact image that was built or reused:
+
+```bash
+cat > preview-images.json <<'JSON'
+{
+  "api": "ghcr.io/acme/api@sha256:abcd..."
+}
+JSON
+
+pnpm tsops up preview --var pr=857 --image-digests @preview-images.json
+```
+
+`--image-digests` rejects unknown app names and mutable tags before applying
+manifests.
+
 ### Git Reference Options
 
 ```bash

--- a/docs/guide/preview-overlays.md
+++ b/docs/guide/preview-overlays.md
@@ -8,12 +8,24 @@ the fixture in `examples/preview-namespaces/tsops.config.ts`.
 
 ```bash
 tsops up preview --var pr=857
+tsops up preview --var pr=857 --image-digests @preview-images.json
 tsops down preview --var pr=857
 tsops down preview --var pr=857 --keep-database
 ```
 
 `tsops up` supports `--skip-cert` and `--skip-database` for operator debugging.
 Product orchestration should not use those flags for normal previews.
+
+Use `--image-digests` when CI has already built preview images and should deploy
+exactly those immutable refs. The file is a JSON object keyed by tsops app name:
+
+```json
+{
+  "api": "ghcr.io/example/api@sha256:abcd..."
+}
+```
+
+tsops rejects unknown app keys and mutable tags before planning the rollout.
 
 ## Hook Order
 

--- a/examples/monorepo/tsops.config.ts
+++ b/examples/monorepo/tsops.config.ts
@@ -32,8 +32,17 @@ const config = defineConfig({
     backend: {
       build: {
         type: 'dockerfile',
-        context: 'examples/monorepo/apps/backend',
+        context: 'examples/monorepo',
         dockerfile: 'examples/monorepo/apps/backend/Dockerfile',
+        inputs: [
+          'apps/backend/**',
+          'package.json',
+          'pnpm-lock.yaml',
+          'pnpm-workspace.yaml',
+          'turbo.json',
+          'tsconfig.base.json'
+        ],
+        cache: { type: 'registry', mode: 'max' },
         env: { DOCKER_BUILDKIT: '1' },
         args: {
           PACKAGE_NAME: '@monorepo/backend',
@@ -54,8 +63,17 @@ const config = defineConfig({
     frontend: {
       build: {
         type: 'dockerfile',
-        context: 'examples/monorepo/apps/frontend',
+        context: 'examples/monorepo',
         dockerfile: 'examples/monorepo/apps/frontend/Dockerfile',
+        inputs: [
+          'apps/frontend/**',
+          'package.json',
+          'pnpm-lock.yaml',
+          'pnpm-workspace.yaml',
+          'turbo.json',
+          'tsconfig.base.json'
+        ],
+        cache: { type: 'registry', mode: 'max' },
         env: { DOCKER_BUILDKIT: '1' },
         args: {
           PACKAGE_NAME: '@monorepo/frontend',

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,6 +53,7 @@ Builds and pushes Docker images for configured apps.
 tsops build
 tsops build --app api
 tsops build --app api --namespace prod  # Determines dev/prod platform
+tsops build --source-key                # Reuse image tags derived from build inputs
 ```
 
 **Incremental builds (monorepo optimization):**
@@ -73,13 +74,33 @@ tsops build --force
 
 The `--filter` flag compares changed files against the specified git reference and builds only applications whose `build.context` directory contains changed files. This is especially useful in CI/CD pipelines for monorepo projects where you want to build only what changed.
 
+**Source-key image reuse:**
+
+Use `build.inputs` in `tsops.config.ts` or pass `--source-key` to tag images as `source-<hash>` before checking the registry. The hash includes selected file contents, the Dockerfile, common lock/config files when present, and build metadata such as args, env, target, platform, source-key settings, and cache settings. When the tag already exists, tsops skips the Docker build and resolves the immutable digest ref for deployment handoff.
+
+```typescript
+apps: {
+  api: {
+    build: {
+      type: 'dockerfile',
+      context: '.',
+      dockerfile: 'apps/api/Dockerfile',
+      inputs: ['apps/api/**', 'packages/shared/**', 'package.json', 'pnpm-lock.yaml'],
+      cache: { type: 'registry', mode: 'max' }
+    }
+  }
+}
+```
+
+`cache: { type: 'registry' }` makes the Node Docker adapter use BuildKit registry cache flags. If `cache.ref` is omitted, tsops uses the image repository with a `:cache` tag.
+
 **Output example:**
 ```
 📊 Detected 3 changed file(s) compared to HEAD^1
 Building 1 affected app(s): api
 
 ✅ Built images:
-   • api: ghcr.io/org/api:abc123
+   • api: ghcr.io/org/api@sha256:abcd... [tag: ghcr.io/org/api:source-feedface] (reused)
 ```
 
 #### `deploy`
@@ -91,7 +112,18 @@ tsops deploy
 tsops deploy --namespace prod
 tsops deploy --app api
 tsops deploy --namespace prod --app api
+tsops deploy --namespace prod --image-digests @images.json
 ```
+
+`--image-digests` accepts either an inline JSON object or an `@file` path mapping app names to immutable image digest refs:
+
+```json
+{
+  "api": "ghcr.io/org/api@sha256:abcd..."
+}
+```
+
+Unknown app names and mutable tags are rejected before manifests are applied.
 
 **Output example:**
 ```
@@ -115,6 +147,11 @@ Build-specific options:
 
 - **`--filter <ref>`** – Build only apps affected by changes compared to git ref (e.g., `HEAD^1`, `main`, `origin/main`)
 - **`-f, --force`** – Force rebuild even if image already exists in registry
+- **`--source-key`** – Reuse image tags derived from source inputs and build metadata
+
+Deploy/up-specific options:
+
+- **`--image-digests <json-or-file>`** – Override app images with immutable digest refs, using inline JSON or an `@file` path
 
 ### Help
 
@@ -338,4 +375,3 @@ The CLI binary is defined in `package.json`:
   }
 }
 ```
-

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,7 +72,7 @@ tsops build --filter origin/main
 tsops build --force
 ```
 
-The `--filter` flag compares changed files against the specified git reference and builds only applications whose `build.context` directory contains changed files. This is especially useful in CI/CD pipelines for monorepo projects where you want to build only what changed.
+The `--filter` flag compares changed files against the specified git reference and builds only affected applications. Apps with `build.inputs` or `sourceKey: { mode: 'inputs' }` use those patterns relative to `build.context`; other apps fall back to matching the full `build.context` directory. This is especially useful in CI/CD pipelines for monorepo projects where you want to build only what changed.
 
 **Source-key image reuse:**
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -305,6 +305,7 @@ async function main(): Promise<void> {
     .option('-c, --config <path>', 'path to config file', 'tsops.config')
     .option('--dry-run', 'skip external commands, log actions only')
     .option('-f, --force', 'force rebuild even if image already exists in registry')
+    .option('--source-key', 'reuse images by content-addressed source key')
     .option(
       '--filter <ref>',
       'build only apps affected by changes compared to git ref (e.g., HEAD^1, main, origin/main)'
@@ -337,7 +338,8 @@ async function main(): Promise<void> {
         namespace: options.namespace,
         app: options.app,
         force: options.force,
-        changedFiles
+        changedFiles,
+        sourceKey: options.sourceKey
       })
 
       if (result.images.length === 0) {
@@ -347,7 +349,9 @@ async function main(): Promise<void> {
 
       console.log('\n✅ Built images:')
       for (const item of result.images) {
-        console.log(`   • ${item.app}: ${item.image}`)
+        const reuse = item.reused ? ' (reused)' : ''
+        const tag = item.tag && item.tag !== item.image ? ` [tag: ${item.tag}]` : ''
+        console.log(`   • ${item.app}: ${item.image}${tag}${reuse}`)
       }
     })
 
@@ -358,13 +362,21 @@ async function main(): Promise<void> {
     .option('--app <name>', 'target a single app')
     .option('-c, --config <path>', 'path to config file', 'tsops.config')
     .option('--dry-run', 'skip external commands, log actions only')
+    .option(
+      '--image-digests <json-or-file>',
+      'JSON object or @file mapping app names to immutable image digest refs'
+    )
     .action(async (options) => {
       const config = await loadConfig(options.config)
       const tsops = createNodeTsOps(config, {
         dryRun: options.dryRun,
         env: new GitEnvironmentProvider(new ProcessEnvironmentProvider())
       })
-      const result = await tsops.deploy({ namespace: options.namespace, app: options.app })
+      const result = await tsops.deploy({
+        namespace: options.namespace,
+        app: options.app,
+        imageOverrides: readImageDigestOverrides(options.imageDigests)
+      })
 
       console.log('✅ Deployed applications:')
       for (const entry of result.entries) {
@@ -395,6 +407,10 @@ async function main(): Promise<void> {
     .option('--base-ref <ref>', 'git ref to diff against (default: origin/main)', 'origin/main')
     .option('--skip-cert', 'skip the per-namespace certificate hook')
     .option('--skip-database', 'skip the schema-per-overlay database hook')
+    .option(
+      '--image-digests <json-or-file>',
+      'JSON object or @file mapping app names to immutable image digest refs'
+    )
     .option('-c, --config <path>', 'path to config file', 'tsops.config')
     .option('--dry-run', 'skip external commands, log actions only')
     .action(async (namespace: string, options) => {
@@ -407,6 +423,7 @@ async function main(): Promise<void> {
       })
 
       const vars = options.var as Record<string, string>
+      const imageOverrides = readImageDigestOverrides(options.imageDigests)
       let include: string[] | undefined
 
       if (options.include) {
@@ -447,11 +464,15 @@ async function main(): Promise<void> {
       if (include && include.length > 0) {
         console.log(`   include: ${include.join(', ')}`)
       }
+      if (imageOverrides) {
+        console.log(`   image digests: ${Object.keys(imageOverrides).join(', ')}`)
+      }
 
       const result = await tsops.deploy({
         namespace,
         vars,
         include,
+        imageOverrides,
         skipCert: options.skipCert,
         skipDatabase: options.skipDatabase
       })
@@ -535,6 +556,23 @@ function collectVar(value: string, previous: Record<string, string>): Record<str
   const val = value.slice(eq + 1)
   if (!key) throw new Error(`Invalid --var "${value}": empty key`)
   return { ...previous, [key]: val }
+}
+
+function readImageDigestOverrides(input: string | undefined): Record<string, string> | undefined {
+  if (!input) return undefined
+  const raw = input.startsWith('@') ? fs.readFileSync(input.slice(1), 'utf8') : input
+  const parsed = JSON.parse(raw) as unknown
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('--image-digests must be a JSON object mapping app names to image refs')
+  }
+  const overrides: Record<string, string> = {}
+  for (const [app, image] of Object.entries(parsed)) {
+    if (typeof image !== 'string') {
+      throw new Error(`--image-digests value for "${app}" must be a string`)
+    }
+    overrides[app] = image
+  }
+  return overrides
 }
 
 async function loadConfig(configPath: string): Promise<any> {

--- a/packages/core/src/config/apps.ts
+++ b/packages/core/src/config/apps.ts
@@ -117,8 +117,11 @@ export function createAppsResolver<TConfig extends TsOpsConfig<any, any, any, an
   }
 
   /**
-   * Selects apps that have changed files in their build context.
-   * Useful for incremental builds in monorepo scenarios.
+   * Selects apps that have changed files in their build inputs or context.
+   * Useful for incremental builds in monorepo scenarios. When `build.inputs`
+   * or `sourceKey: { mode: "inputs" }` is configured, those patterns are
+   * evaluated relative to `build.context` before falling back to the whole
+   * context directory.
    *
    * @param changedFiles - Array of changed file paths relative to repository root
    * @returns Array of [appName, appDefinition] tuples for affected apps
@@ -127,7 +130,7 @@ export function createAppsResolver<TConfig extends TsOpsConfig<any, any, any, an
    * ```typescript
    * const changedFiles = ['packages/api/src/index.ts', 'packages/frontend/app/page.tsx']
    * const affectedApps = resolver.apps.selectByChangedFiles(changedFiles)
-   * // Returns apps with build.context that matches changed files
+   * // Returns apps with build.inputs/build.context that match changed files
    * ```
    */
   function selectByChangedFiles(changedFiles: string[]): AppEntry<TConfig>[] {
@@ -137,26 +140,16 @@ export function createAppsResolver<TConfig extends TsOpsConfig<any, any, any, an
     const affected: AppEntry<TConfig>[] = []
 
     for (const [appName, app] of entries) {
-      const build = app.build
-      if (!build || typeof build !== 'object' || !('context' in build)) {
-        continue
-      }
+      const build = getSelectableBuild(app.build)
+      if (!build) continue
 
-      const context = (build as { context: string }).context
-
-      // Normalize context path (remove trailing slash)
-      const normalizedContext = context.replace(/\/$/, '')
-
-      // Check if any changed file is within this app's build context
-      const isAffected = changedFiles.some((file) => {
-        // Normalize file path
-        const normalizedFile = file.replace(/\/$/, '')
-
-        // Check if file is within the app's context directory
-        return (
-          normalizedFile === normalizedContext || normalizedFile.startsWith(`${normalizedContext}/`)
-        )
-      })
+      const inputPatterns = getBuildInputPatterns(build)
+      const isAffected =
+        inputPatterns.length > 0
+          ? changedFiles.some((file) =>
+              changedFileMatchesInputs(file, build.context, inputPatterns)
+            )
+          : changedFiles.some((file) => changedFileMatchesContext(file, build.context))
 
       if (isAffected) {
         affected.push([appName, app])
@@ -164,6 +157,104 @@ export function createAppsResolver<TConfig extends TsOpsConfig<any, any, any, an
     }
 
     return affected
+  }
+
+  type SelectableBuild = {
+    context: string
+    inputs?: readonly string[]
+    sourceKey?: unknown
+  }
+
+  function getSelectableBuild(build: unknown): SelectableBuild | undefined {
+    if (!isRecord(build) || typeof build.context !== 'string') return undefined
+    const inputs = isStringArray(build.inputs) ? build.inputs : undefined
+    return {
+      context: build.context,
+      ...(inputs ? { inputs } : {}),
+      sourceKey: build.sourceKey
+    }
+  }
+
+  function getBuildInputPatterns(build: SelectableBuild): readonly string[] {
+    if (build.inputs && build.inputs.length > 0) return build.inputs
+    const sourceKey = build.sourceKey
+    if (
+      isRecord(sourceKey) &&
+      sourceKey.mode === 'inputs' &&
+      isStringArray(sourceKey.inputs) &&
+      sourceKey.inputs.length > 0
+    ) {
+      return sourceKey.inputs
+    }
+    return []
+  }
+
+  function changedFileMatchesInputs(
+    changedFile: string,
+    context: string,
+    inputPatterns: readonly string[]
+  ): boolean {
+    const relativeFile = relativeToContext(changedFile, context)
+    if (relativeFile === undefined) return false
+    return inputPatterns.some((pattern) => matchesInputPattern(relativeFile, pattern))
+  }
+
+  function changedFileMatchesContext(changedFile: string, context: string): boolean {
+    return relativeToContext(changedFile, context) !== undefined
+  }
+
+  function relativeToContext(changedFile: string, context: string): string | undefined {
+    const normalizedFile = normalizeConfigPath(changedFile)
+    const normalizedContext = normalizeConfigPath(context)
+    if (normalizedContext === '.' || normalizedContext === '') return normalizedFile
+    if (normalizedFile === normalizedContext) return ''
+    const contextPrefix = `${normalizedContext}/`
+    return normalizedFile.startsWith(contextPrefix)
+      ? normalizedFile.slice(contextPrefix.length)
+      : undefined
+  }
+
+  function matchesInputPattern(changedFile: string, pattern: string): boolean {
+    const normalizedFile = normalizeConfigPath(changedFile)
+    const normalizedPattern = normalizeConfigPath(pattern)
+    if (normalizedPattern === '**' || normalizedPattern === '**/*') return true
+    if (!hasGlob(normalizedPattern)) {
+      return (
+        normalizedFile === normalizedPattern ||
+        normalizedFile.startsWith(`${normalizedPattern.replace(/\/$/, '')}/`)
+      )
+    }
+    if (normalizedPattern.endsWith('/**')) {
+      const prefix = normalizedPattern.slice(0, -3)
+      return normalizedFile === prefix || normalizedFile.startsWith(`${prefix}/`)
+    }
+    return globToRegExp(normalizedPattern).test(normalizedFile)
+  }
+
+  function normalizeConfigPath(path: string): string {
+    return path.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '')
+  }
+
+  function hasGlob(pattern: string): boolean {
+    return /[*?]/.test(pattern)
+  }
+
+  function globToRegExp(pattern: string): RegExp {
+    const escaped = pattern
+      .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*\*/g, '\0')
+      .replace(/\*/g, '[^/]*')
+      .replace(/\?/g, '[^/]')
+      .replace(/\0/g, '.*')
+    return new RegExp(`^${escaped}$`)
+  }
+
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+  }
+
+  function isStringArray(value: unknown): value is readonly string[] {
+    return Array.isArray(value) && value.every((item) => typeof item === 'string')
   }
 
   /**

--- a/packages/core/src/config/build.ts
+++ b/packages/core/src/config/build.ts
@@ -1,4 +1,9 @@
-import type { AppBuildContext, DockerfileBuild } from '../types.js'
+import type {
+  AppBuildContext,
+  BuildSourceKeyConfig,
+  DockerBuildCacheConfig,
+  DockerfileBuild
+} from '../types.js'
 
 /**
  * Fields that sensibly carry default values across many apps in the same repo.
@@ -10,6 +15,9 @@ export interface DockerfileBuildDefaults {
   env?: Record<string, string>
   args?: Record<string, string>
   target?: string
+  inputs?: readonly string[]
+  sourceKey?: BuildSourceKeyConfig
+  cache?: DockerBuildCacheConfig
 }
 
 /**
@@ -37,6 +45,9 @@ export function defineDockerfileBuild(defaults: DockerfileBuildDefaults = {}) {
     const mergedArgs = mergeRecord(defaults.args, overrides.args)
     const platform = overrides.platform ?? defaults.platform
     const target = overrides.target ?? defaults.target
+    const inputs = overrides.inputs ?? defaults.inputs
+    const sourceKey = overrides.sourceKey ?? defaults.sourceKey
+    const cache = overrides.cache ?? defaults.cache
 
     const result: DockerfileBuild = {
       type: 'dockerfile',
@@ -48,6 +59,9 @@ export function defineDockerfileBuild(defaults: DockerfileBuildDefaults = {}) {
     if (target !== undefined) result.target = target
     if (mergedEnv) result.env = mergedEnv
     if (mergedArgs) result.args = mergedArgs
+    if (inputs !== undefined) result.inputs = inputs
+    if (sourceKey !== undefined) result.sourceKey = sourceKey
+    if (cache !== undefined) result.cache = cache
 
     return result
   }

--- a/packages/core/src/config/images.ts
+++ b/packages/core/src/config/images.ts
@@ -12,7 +12,7 @@ export interface ImagesResolver<TConfig extends TsOpsConfig<any, any, any, any, 
    * @param appName - The application name
    * @returns Full image reference (e.g., "ghcr.io/org/app:abc123")
    */
-  buildRef(appName: string): string
+  buildRef(appName: string, options?: { tag?: string }): string
 }
 
 export function createImagesResolver<TConfig extends TsOpsConfig<any, any, any, any, any, any>>(
@@ -61,9 +61,9 @@ export function createImagesResolver<TConfig extends TsOpsConfig<any, any, any, 
     return 'latest'
   }
 
-  function buildRef(appName: string): string {
+  function buildRef(appName: string, options: { tag?: string } = {}): string {
     const base = resolveRepository(appName)
-    const tag = resolveTag()
+    const tag = options.tag ?? resolveTag()
     return `${base}:${tag}`
   }
 

--- a/packages/core/src/operations/builder.ts
+++ b/packages/core/src/operations/builder.ts
@@ -25,7 +25,13 @@ export class Builder<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
   }
 
   async build(
-    options: { app?: string; namespace?: string; force?: boolean; changedFiles?: string[] } = {}
+    options: {
+      app?: string
+      namespace?: string
+      force?: boolean
+      changedFiles?: string[]
+      sourceKey?: boolean
+    } = {}
   ): Promise<BuildResult> {
     // Login to Docker registry before building (reads from env vars)
     await this.docker.login()
@@ -63,7 +69,8 @@ export class Builder<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
         continue
       }
 
-      const imageRef = this.resolver.images.buildRef(appName)
+      let imageRef = this.resolver.images.buildRef(appName)
+      let sourceKey: string | undefined
       if (!isDockerfileBuild(build)) {
         this.logger.warn('Skipping unsupported build configuration. Expected type "dockerfile".', {
           app: appName
@@ -71,15 +78,33 @@ export class Builder<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
         continue
       }
 
+      if (shouldUseSourceKey(build, options.sourceKey)) {
+        if (!this.docker.sourceKey) {
+          throw new Error(
+            `Docker adapter does not support source-key image reuse for app "${appName}"`
+          )
+        }
+        sourceKey = normalizeSourceKey(await this.docker.sourceKey(appName, build, {}), appName)
+        imageRef = this.resolver.images.buildRef(appName, { tag: `source-${sourceKey}` })
+      }
+
       // Check if image already exists in registry (unless force rebuild is requested)
       if (!options.force) {
         const exists = await this.docker.imageExists(imageRef)
         if (exists) {
+          const digest = await this.resolveDigest(imageRef)
           this.logger.info('Image already exists in registry. Skipping build.', {
             app: appName,
             image: imageRef
           })
-          results.push({ app: appName, image: imageRef })
+          results.push({
+            app: appName,
+            image: toDeployImageRef(imageRef, digest),
+            tag: imageRef,
+            digest,
+            sourceKey,
+            reused: true
+          })
           continue
         }
       } else {
@@ -90,14 +115,28 @@ export class Builder<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
       }
 
       // Build context can be extended with namespace variables if needed
-      await this.docker.build(imageRef, build, {})
-      if (!this.dryRun) {
+      const buildResult = await this.docker.build(imageRef, build, {})
+      if (!this.dryRun && !buildResult?.pushed) {
         await this.docker.push(imageRef)
       }
-      results.push({ app: appName, image: imageRef })
+      const digest = buildResult?.digest ?? (await this.resolveDigest(imageRef))
+      results.push({
+        app: appName,
+        image: toDeployImageRef(imageRef, digest),
+        tag: imageRef,
+        digest,
+        sourceKey,
+        reused: false
+      })
     }
 
     return { images: results }
+  }
+
+  private async resolveDigest(imageRef: string): Promise<string | undefined> {
+    if (!this.docker.resolveDigest) return undefined
+    const digest = await this.docker.resolveDigest(imageRef)
+    return digest ?? undefined
   }
 }
 
@@ -110,4 +149,31 @@ function isDockerfileBuild(build: BuildDefinition): build is DockerfileBuild {
     typeof candidate.context === 'string' &&
     typeof candidate.dockerfile === 'string'
   )
+}
+
+function shouldUseSourceKey(build: DockerfileBuild, option?: boolean): boolean {
+  if (build.sourceKey === false) return false
+  if (option) return true
+  if (build.inputs && build.inputs.length > 0) return true
+  return build.sourceKey !== undefined
+}
+
+function normalizeSourceKey(sourceKey: string, appName: string): string {
+  const normalized = sourceKey
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, '-')
+    .replace(/^-+/, '')
+    .slice(0, 100)
+  if (!normalized) throw new Error(`Invalid empty source key for app "${appName}"`)
+  return normalized
+}
+
+function toDeployImageRef(imageRef: string, digest: string | undefined): string {
+  if (!digest) return imageRef
+  if (imageRef.includes('@')) return imageRef
+  const tagSeparator = imageRef.lastIndexOf(':')
+  const pathSeparator = imageRef.lastIndexOf('/')
+  const repository = tagSeparator > pathSeparator ? imageRef.slice(0, tagSeparator) : imageRef
+  return `${repository}@${digest}`
 }

--- a/packages/core/src/operations/deployer.ts
+++ b/packages/core/src/operations/deployer.ts
@@ -14,6 +14,7 @@ import { runCertbotHook } from './cert-hook.js'
 import { runDatabasePostDestroy, runDatabasePreDeploy } from './db-hook.js'
 import type { Planner } from './planner.js'
 import type {
+  ImageDigestOverrides,
   AppResourceChanges,
   DeployResult,
   ManifestChange,
@@ -62,6 +63,7 @@ export class Deployer<TConfig extends TsOpsConfig<any, any, any, any, any, any>>
       app?: string
       vars?: OverlayVars
       include?: readonly string[]
+      imageOverrides?: ImageDigestOverrides
       skipCert?: boolean
       skipDatabase?: boolean
     } = {}

--- a/packages/core/src/operations/planner.ts
+++ b/packages/core/src/operations/planner.ts
@@ -13,7 +13,9 @@ import {
   scanBuildEnv,
   scanRuntimeEnv
 } from '../validation/sensitive-env.js'
-import type { PlanEntry, PlanResult } from './types.js'
+import type { ImageDigestOverrides, PlanEntry, PlanResult } from './types.js'
+
+const immutableDigestRefPattern = /^.+@sha256:[a-f0-9]{64}$/
 
 /**
  * Dependencies required by Planner.
@@ -66,12 +68,15 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
       vars?: OverlayVars
       /** When set, only these apps deploy normally; others fall back via ExternalName. */
       include?: readonly string[]
+      /** Immutable image refs keyed by app name. */
+      imageOverrides?: ImageDigestOverrides
     } = {}
   ): Promise<PlanResult> {
     const namespaces = this.resolver.namespaces.select(options.namespace, options.vars)
     const apps = this.resolver.apps.select(options.app)
     const allAppsForDeps = this.resolver.apps.select()
     const knownAppNames = new Set(allAppsForDeps.map(([name]) => name))
+    validateImageOverrides(options.imageOverrides, knownAppNames)
     const entries: PlanEntry[] = []
     const includeSet = options.include ? new Set(options.include) : undefined
 
@@ -111,7 +116,8 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
         const secrets = this.resolver.apps.resolveSecrets(app, namespace, context)
         const configMaps = this.resolver.apps.resolveConfigMaps(app, namespace, context)
         // Use app.image if provided (for external images), otherwise build from registry
-        const image = app.image || this.resolver.images.buildRef(appName)
+        const image =
+          options.imageOverrides?.[appName] ?? app.image ?? this.resolver.images.buildRef(appName)
         const { network, host } = this.resolver.apps.resolveNetwork(appName, app, context)
 
         const resolveParam = <T>(
@@ -323,6 +329,21 @@ export class Planner<TConfig extends TsOpsConfig<any, any, any, any, any, any>> 
       entries,
       warnings: findings,
       dependencies: hasAnyDeps ? dependencies : undefined
+    }
+  }
+}
+
+function validateImageOverrides(
+  overrides: ImageDigestOverrides | undefined,
+  knownAppNames: ReadonlySet<string>
+): void {
+  if (!overrides) return
+  for (const [app, image] of Object.entries(overrides)) {
+    if (!knownAppNames.has(app)) {
+      throw new Error(`Unknown image override app "${app}"`)
+    }
+    if (!immutableDigestRefPattern.test(image)) {
+      throw new Error(`Image override for app "${app}" must be an immutable digest ref`)
     }
   }
 }

--- a/packages/core/src/operations/types.ts
+++ b/packages/core/src/operations/types.ts
@@ -1,6 +1,8 @@
 import type { ResolvedNetworkConfig } from '@tsops/k8'
 import type { ConfigMapRef, EnvValue, SecretRef } from '../types.js'
 
+export type ImageDigestOverrides = Record<string, string>
+
 export interface PlanEntry {
   namespace: string
   app: string
@@ -78,7 +80,16 @@ export interface PlanResult {
 }
 
 export interface BuildResult {
-  images: { app: string; image: string }[]
+  images: Array<{
+    app: string
+    /** Immutable digest ref when available; otherwise the mutable tag ref. */
+    image: string
+    /** Mutable tag used as the build/reuse index. */
+    tag?: string
+    digest?: string
+    sourceKey?: string
+    reused?: boolean
+  }>
 }
 
 export interface DeployResult {

--- a/packages/core/src/ports/docker.ts
+++ b/packages/core/src/ports/docker.ts
@@ -8,7 +8,13 @@ export interface DockerLoginOptions {
 
 export interface DockerClient {
   login(options?: DockerLoginOptions): Promise<void>
+  sourceKey?(appName: string, build: DockerfileBuild, ctx: AppBuildContext): Promise<string>
   imageExists(imageRef: string): Promise<boolean>
-  build(imageRef: string, build: DockerfileBuild, ctx: AppBuildContext): Promise<void>
+  resolveDigest?(imageRef: string): Promise<string | null>
+  build(
+    imageRef: string,
+    build: DockerfileBuild,
+    ctx: AppBuildContext
+  ): Promise<{ digest?: string; pushed?: boolean } | void>
   push(imageRef: string): Promise<void>
 }

--- a/packages/core/src/tsops.ts
+++ b/packages/core/src/tsops.ts
@@ -5,6 +5,7 @@ import { ConsoleLogger, type Logger } from './logger.js'
 import { Builder } from './operations/builder.js'
 import { Deployer } from './operations/deployer.js'
 import { Planner } from './operations/planner.js'
+import type { ImageDigestOverrides } from './operations/types.js'
 import type { DockerClient } from './ports/docker.js'
 import type { KubectlClient } from './ports/kubectl.js'
 import type { OverlayVars, TsOpsConfig } from './types.js'
@@ -130,6 +131,8 @@ export class TsOps<TConfig extends TsOpsConfig<any, any, any, any, any, any, any
        * when `namespace` targets an overlay.
        */
       vars?: OverlayVars
+      /** Immutable image refs keyed by app name. */
+      imageOverrides?: ImageDigestOverrides
     } = {}
   ) {
     return this.planner.plan(options)
@@ -205,7 +208,13 @@ export class TsOps<TConfig extends TsOpsConfig<any, any, any, any, any, any, any
    * ```
    */
   build(
-    options: { app?: string; namespace?: string; force?: boolean; changedFiles?: string[] } = {}
+    options: {
+      app?: string
+      namespace?: string
+      force?: boolean
+      changedFiles?: string[]
+      sourceKey?: boolean
+    } = {}
   ) {
     return this.builder.build(options)
   }
@@ -236,6 +245,8 @@ export class TsOps<TConfig extends TsOpsConfig<any, any, any, any, any, any, any
        * fallback namespace. Only meaningful when targeting an overlay.
        */
       include?: readonly string[]
+      /** Immutable image refs keyed by app name. */
+      imageOverrides?: ImageDigestOverrides
       /** Skip the per-namespace certificate hook (cert.* in config). */
       skipCert?: boolean
       /** Skip the schema-per-overlay database hook (database.* in config). */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -318,6 +318,23 @@ export type ImagesConfig = {
  */
 export type AppBuildContext = Record<string, unknown>
 
+export type BuildSourceKeyConfig =
+  | boolean
+  | string
+  | ((ctx: AppBuildContext) => string | Promise<string>)
+  | { mode?: 'context' }
+  | { mode: 'inputs'; inputs: readonly string[] }
+  | {
+      mode: 'custom'
+      value: string | ((ctx: AppBuildContext) => string | Promise<string>)
+    }
+
+export type DockerBuildCacheConfig = {
+  type: 'registry'
+  ref?: string
+  mode?: 'min' | 'max'
+}
+
 export type DockerfileBuild = {
   type: 'dockerfile'
   context: string
@@ -326,6 +343,12 @@ export type DockerfileBuild = {
   env?: Record<string, string>
   args?: Record<string, string>
   target?: string
+  /** Explicit file/glob inputs used for content-addressed image reuse. */
+  inputs?: readonly string[]
+  /** Enables or customizes source-key image reuse for this build. */
+  sourceKey?: BuildSourceKeyConfig
+  /** Optional Docker BuildKit cache configuration. */
+  cache?: DockerBuildCacheConfig
 } & Record<string, unknown>
 
 export type GenericBuild = Record<string, unknown>

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -22,7 +22,9 @@
     "lint": "pnpm -w exec eslint ."
   },
   "dependencies": {
-    "@tsops/core": "workspace:*"
+    "@tsops/core": "workspace:*",
+    "globby": "^11.1.0",
+    "ignore": "^5.3.2"
   },
   "keywords": [
     "tsops",

--- a/packages/node/src/adapters/docker.ts
+++ b/packages/node/src/adapters/docker.ts
@@ -1,7 +1,16 @@
 import type { AppBuildContext, DockerfileBuild, Logger } from '@tsops/core'
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { join, relative, resolve, sep } from 'node:path'
+import globby from 'globby'
+import type { Ignore } from 'ignore'
 import type { CommandRunner } from '../command-runner.js'
 
 export type DockerBuildContext = AppBuildContext
+
+const require = createRequire(import.meta.url)
+const createIgnore = require('ignore') as typeof import('ignore').default
 
 export interface DockerServiceOptions {
   runner: CommandRunner
@@ -101,7 +110,108 @@ export class Docker {
     }
   }
 
-  async build(imageRef: string, build: DockerfileBuild, ctx: DockerBuildContext): Promise<void> {
+  async resolveDigest(imageRef: string): Promise<string | null> {
+    this.logger.debug('Resolving image digest', { imageRef })
+
+    if (this.dryRun) {
+      this.logger.debug('Dry run enabled – skipping digest resolution', { imageRef })
+      return null
+    }
+
+    try {
+      const output = await this.runner.run(
+        'docker',
+        ['buildx', 'imagetools', 'inspect', imageRef, '--format', '{{json .Manifest.Digest}}'],
+        {
+          captureOutput: true,
+          inheritStdio: false,
+          onStdout: (data) =>
+            this.logger.debug('docker imagetools stdout', { output: data.trim() }),
+          onStderr: (data) => this.logger.debug('docker imagetools stderr', { output: data.trim() })
+        }
+      )
+      const digest = output.trim().replace(/^"|"$/g, '')
+      return /^sha256:[a-f0-9]{64}$/.test(digest) ? digest : null
+    } catch (error) {
+      this.logger.debug('Could not resolve image digest', {
+        imageRef,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return null
+    }
+  }
+
+  async sourceKey(
+    appName: string,
+    build: DockerfileBuild,
+    ctx: DockerBuildContext
+  ): Promise<string> {
+    const sourceKey = build.sourceKey
+    const custom = await resolveCustomSourceKey(sourceKey, ctx)
+    const hash = createHash('sha256')
+    hash.update('tsops-source-key-v1\0')
+    hash.update(appName)
+    hash.update('\0')
+
+    if (custom !== undefined) {
+      hash.update('custom\0')
+      hash.update(custom)
+      return hash.digest('hex')
+    }
+
+    const contextRoot = resolve(build.context)
+    const patterns = resolveSourceKeyPatterns(build)
+    const dockerIgnore = await readDockerIgnore(contextRoot)
+    const files = await globby(patterns, {
+      cwd: contextRoot,
+      dot: true,
+      onlyFiles: true,
+      followSymbolicLinks: false,
+      gitignore: false
+    })
+    const normalizedFiles = new Set<string>()
+    for (const file of files) {
+      const normalized = normalizePath(file)
+      if (!dockerIgnore.ignores(normalized)) normalizedFiles.add(normalized)
+    }
+
+    for (const extra of await findExistingCommonInputs(contextRoot)) {
+      if (!dockerIgnore.ignores(extra)) normalizedFiles.add(extra)
+    }
+
+    const dockerfile = normalizePath(relative(contextRoot, resolve(build.dockerfile)))
+    if (dockerfile && !dockerIgnore.ignores(dockerfile)) normalizedFiles.add(dockerfile)
+
+    hash.update(
+      `${stableStringify({
+        appName,
+        args: build.args ?? {},
+        cache: build.cache ?? null,
+        context: normalizePath(build.context),
+        dockerfile: normalizePath(build.dockerfile),
+        env: build.env ?? {},
+        inputs: build.inputs ?? null,
+        platform:
+          typeof build.platform === 'function' ? build.platform(ctx) : (build.platform ?? null),
+        sourceKey: normalizeSourceKeyConfig(build.sourceKey),
+        target: build.target ?? null
+      })}\0`
+    )
+
+    for (const file of [...normalizedFiles].sort()) {
+      hash.update(`file:${file}\0`)
+      hash.update(await readFile(join(contextRoot, file)))
+      hash.update('\0')
+    }
+
+    return hash.digest('hex')
+  }
+
+  async build(
+    imageRef: string,
+    build: DockerfileBuild,
+    ctx: DockerBuildContext
+  ): Promise<{ digest?: string; pushed?: boolean } | void> {
     if (!('type' in build) || build.type !== 'dockerfile') {
       this.logger.warn('Skipping unsupported build configuration. Expected type "dockerfile".', {
         imageRef
@@ -109,7 +219,18 @@ export class Docker {
       return
     }
 
-    const args = ['build', build.context, '--file', build.dockerfile, '--tag', imageRef] as string[]
+    const usesBuildKitRegistryCache = build.cache?.type === 'registry'
+    const args = usesBuildKitRegistryCache
+      ? ([
+          'buildx',
+          'build',
+          build.context,
+          '--file',
+          build.dockerfile,
+          '--tag',
+          imageRef
+        ] as string[])
+      : (['build', build.context, '--file', build.dockerfile, '--tag', imageRef] as string[])
 
     if (typeof build.platform === 'string') {
       args.push('--platform', build.platform)
@@ -124,6 +245,17 @@ export class Docker {
 
     if (build.target) {
       args.push('--target', build.target)
+    }
+
+    if (usesBuildKitRegistryCache) {
+      const cacheRef = build.cache?.ref ?? defaultRegistryCacheRef(imageRef)
+      args.push(
+        '--cache-from',
+        `type=registry,ref=${cacheRef}`,
+        '--cache-to',
+        `type=registry,ref=${cacheRef},mode=${build.cache?.mode ?? 'max'}`,
+        '--load'
+      )
     }
 
     this.logger.info('Docker build', { imageRef })
@@ -149,6 +281,97 @@ export class Docker {
 
     await this.runner.run('docker', ['push', imageRef], { inheritStdio: true })
   }
+}
+
+const commonInputFiles = [
+  'package.json',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  'bun.lock',
+  'bun.lockb',
+  'turbo.json',
+  'tsops.config.ts',
+  'tsops.config.js',
+  'tsops.config.mjs'
+]
+
+async function readDockerIgnore(contextRoot: string): Promise<Ignore> {
+  const matcher = createIgnore()
+  try {
+    matcher.add(await readFile(join(contextRoot, '.dockerignore'), 'utf8'))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  return matcher
+}
+
+async function findExistingCommonInputs(contextRoot: string): Promise<string[]> {
+  const existing: string[] = []
+  for (const file of commonInputFiles) {
+    try {
+      await readFile(join(contextRoot, file))
+      existing.push(file)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+  }
+  return existing
+}
+
+async function resolveCustomSourceKey(
+  sourceKey: DockerfileBuild['sourceKey'],
+  ctx: DockerBuildContext
+): Promise<string | undefined> {
+  if (sourceKey === undefined || sourceKey === true || sourceKey === false) return undefined
+  if (typeof sourceKey === 'string') return sourceKey
+  if (typeof sourceKey === 'function') return sourceKey(ctx)
+  if (sourceKey.mode === 'custom') {
+    return typeof sourceKey.value === 'function' ? sourceKey.value(ctx) : sourceKey.value
+  }
+  return undefined
+}
+
+function resolveSourceKeyPatterns(build: DockerfileBuild): string[] {
+  const sourceKey = build.sourceKey
+  if (sourceKey && typeof sourceKey === 'object' && sourceKey.mode === 'inputs') {
+    return [...sourceKey.inputs]
+  }
+  if (build.inputs && build.inputs.length > 0) return [...build.inputs]
+  return ['**/*']
+}
+
+function normalizeSourceKeyConfig(sourceKey: DockerfileBuild['sourceKey']) {
+  if (typeof sourceKey === 'function') return 'function'
+  if (sourceKey && typeof sourceKey === 'object' && sourceKey.mode === 'custom') {
+    return {
+      mode: 'custom',
+      value: typeof sourceKey.value === 'function' ? 'function' : sourceKey.value
+    }
+  }
+  return sourceKey ?? null
+}
+
+function defaultRegistryCacheRef(imageRef: string): string {
+  const tagSeparator = imageRef.lastIndexOf(':')
+  const pathSeparator = imageRef.lastIndexOf('/')
+  const repository = tagSeparator > pathSeparator ? imageRef.slice(0, tagSeparator) : imageRef
+  return `${repository}:cache`
+}
+
+function normalizePath(input: string): string {
+  return input.split(sep).join('/')
+}
+
+function stableStringify(input: unknown): string {
+  if (Array.isArray(input)) return `[${input.map(stableStringify).join(',')}]`
+  if (input && typeof input === 'object') {
+    return `{${Object.entries(input as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => `${JSON.stringify(key)}:${stableStringify(value)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(input)
 }
 
 function appendKeyValue(

--- a/packages/node/src/adapters/docker.ts
+++ b/packages/node/src/adapters/docker.ts
@@ -11,6 +11,8 @@ export type DockerBuildContext = AppBuildContext
 
 const require = createRequire(import.meta.url)
 const createIgnore = require('ignore') as typeof import('ignore').default
+const packageJson = require('../../package.json') as { version?: string }
+const adapterVersion = packageJson.version ?? 'unknown'
 
 export interface DockerServiceOptions {
   runner: CommandRunner
@@ -152,6 +154,9 @@ export class Docker {
     hash.update('tsops-source-key-v1\0')
     hash.update(appName)
     hash.update('\0')
+    hash.update('@tsops/node\0')
+    hash.update(adapterVersion)
+    hash.update('\0')
 
     if (custom !== undefined) {
       hash.update('custom\0')
@@ -178,6 +183,7 @@ export class Docker {
     for (const extra of await findExistingCommonInputs(contextRoot)) {
       if (!dockerIgnore.ignores(extra)) normalizedFiles.add(extra)
     }
+    await addExistingInput(normalizedFiles, contextRoot, '.dockerignore')
 
     const dockerfile = normalizePath(relative(contextRoot, resolve(build.dockerfile)))
     if (dockerfile && !dockerIgnore.ignores(dockerfile)) normalizedFiles.add(dockerfile)
@@ -317,6 +323,19 @@ async function findExistingCommonInputs(contextRoot: string): Promise<string[]> 
     }
   }
   return existing
+}
+
+async function addExistingInput(
+  files: Set<string>,
+  contextRoot: string,
+  file: string
+): Promise<void> {
+  try {
+    await readFile(join(contextRoot, file))
+    files.add(file)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
 }
 
 async function resolveCustomSourceKey(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,12 +68,21 @@ importers:
       '@tsops/core':
         specifier: workspace:*
         version: link:../core
+      globby:
+        specifier: ^11.1.0
+        version: 11.1.0
+      ignore:
+        specifier: ^5.3.2
+        version: 5.3.2
 
   tests:
     dependencies:
       '@tsops/core':
         specifier: workspace:*
         version: link:../packages/core
+      '@tsops/node':
+        specifier: workspace:*
+        version: link:../packages/node
       tsops:
         specifier: workspace:*
         version: link:../packages/cli

--- a/tests/build-source-key.test.ts
+++ b/tests/build-source-key.test.ts
@@ -1,0 +1,335 @@
+import {
+  NullEnvironmentProvider,
+  TsOps,
+  defineConfig,
+  type DockerClient,
+  type DockerfileBuild
+} from '@tsops/core'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Docker } from '@tsops/node'
+import { describe, expect, it } from 'vitest'
+
+const digest = `sha256:${'a'.repeat(64)}`
+const digestRef = `ghcr.io/acme/api@${digest}`
+
+describe('source-key image reuse', () => {
+  it('reuses an existing source-key image and returns an immutable digest ref', async () => {
+    const docker = new RecordingDocker({
+      sourceKey: 'feedface',
+      existingImages: new Set(['ghcr.io/acme/api:source-feedface']),
+      digests: new Map([['ghcr.io/acme/api:source-feedface', digest]])
+    })
+
+    const tsops = makeTsOps(docker)
+    const result = await tsops.build({ app: 'api' })
+
+    expect(docker.sourceKeyCalls).toEqual([
+      {
+        app: 'api',
+        inputs: ['apps/api/**', 'packages/shared/**']
+      }
+    ])
+    expect(docker.imageExistsCalls).toEqual(['ghcr.io/acme/api:source-feedface'])
+    expect(docker.buildCalls).toHaveLength(0)
+    expect(docker.pushCalls).toHaveLength(0)
+    expect(result.images).toEqual([
+      {
+        app: 'api',
+        image: digestRef,
+        tag: 'ghcr.io/acme/api:source-feedface',
+        digest,
+        sourceKey: 'feedface',
+        reused: true
+      }
+    ])
+  })
+
+  it('builds the source-key tag, pushes it, and resolves the digest when no reuse exists', async () => {
+    const docker = new RecordingDocker({
+      sourceKey: 'cafebabe',
+      existingImages: new Set(),
+      digests: new Map([['ghcr.io/acme/api:source-cafebabe', digest]])
+    })
+
+    const tsops = makeTsOps(docker)
+    const result = await tsops.build({ app: 'api' })
+
+    expect(docker.imageExistsCalls).toEqual(['ghcr.io/acme/api:source-cafebabe'])
+    expect(docker.buildCalls).toEqual(['ghcr.io/acme/api:source-cafebabe'])
+    expect(docker.pushCalls).toEqual(['ghcr.io/acme/api:source-cafebabe'])
+    expect(result.images[0]).toMatchObject({
+      image: digestRef,
+      tag: 'ghcr.io/acme/api:source-cafebabe',
+      digest,
+      sourceKey: 'cafebabe',
+      reused: false
+    })
+  })
+})
+
+describe('Node Docker source-key computation', () => {
+  it('hashes explicit build.inputs and always includes Dockerfile and build metadata', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'tsops-source-key-'))
+    await writeFile(join(root, 'Dockerfile'), 'FROM scratch\n')
+    await writeFile(join(root, 'ignored.txt'), 'ignored v1\n')
+    await writeFile(join(root, 'package.json'), '{"name":"fixture"}\n')
+    await writeFile(join(root, 'app.ts'), 'console.log("v1")\n')
+
+    const docker = new Docker({
+      runner: { run: async () => '' },
+      logger: silentLogger,
+      dryRun: true
+    })
+
+    const build: DockerfileBuild = {
+      type: 'dockerfile',
+      context: root,
+      dockerfile: join(root, 'Dockerfile'),
+      inputs: ['app.ts'],
+      args: { NODE_ENV: 'production' }
+    }
+
+    const first = await docker.sourceKey('api', build, {})
+    await writeFile(join(root, 'ignored.txt'), 'ignored v2\n')
+    const afterUnrelatedChange = await docker.sourceKey('api', build, {})
+    await writeFile(join(root, 'app.ts'), 'console.log("v2")\n')
+    const afterInputChange = await docker.sourceKey('api', build, {})
+    const afterArgChange = await docker.sourceKey(
+      'api',
+      {
+        ...build,
+        args: { NODE_ENV: 'development' }
+      },
+      {}
+    )
+
+    expect(afterUnrelatedChange).toBe(first)
+    expect(afterInputChange).not.toBe(first)
+    expect(afterArgChange).not.toBe(afterInputChange)
+  })
+
+  it('uses build.context as the default source-key mode and respects .dockerignore', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'tsops-context-key-'))
+    await writeFile(join(root, 'Dockerfile'), 'FROM scratch\n')
+    await writeFile(join(root, '.dockerignore'), 'ignored.txt\n')
+    await writeFile(join(root, 'ignored.txt'), 'ignored v1\n')
+    await writeFile(join(root, 'app.ts'), 'console.log("v1")\n')
+
+    const docker = new Docker({
+      runner: { run: async () => '' },
+      logger: silentLogger,
+      dryRun: true
+    })
+    const build: DockerfileBuild = {
+      type: 'dockerfile',
+      context: root,
+      dockerfile: join(root, 'Dockerfile'),
+      sourceKey: true
+    }
+
+    const first = await docker.sourceKey('api', build, {})
+    await writeFile(join(root, 'ignored.txt'), 'ignored v2\n')
+    const afterIgnoredChange = await docker.sourceKey('api', build, {})
+    await writeFile(join(root, 'app.ts'), 'console.log("v2")\n')
+    const afterIncludedChange = await docker.sourceKey('api', build, {})
+
+    expect(afterIgnoredChange).toBe(first)
+    expect(afterIncludedChange).not.toBe(first)
+  })
+
+  it('resolves a repo-relative Dockerfile path under the build context', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'tsops-repo-key-'))
+    const previousCwd = process.cwd()
+    await mkdir(join(root, 'examples/monorepo/apps/backend'), { recursive: true })
+    await writeFile(join(root, 'examples/monorepo/apps/backend/Dockerfile'), 'FROM scratch\n')
+    await writeFile(join(root, 'examples/monorepo/apps/backend/index.ts'), 'console.log("v1")\n')
+
+    const docker = new Docker({
+      runner: { run: async () => '' },
+      logger: silentLogger,
+      dryRun: true
+    })
+    const build: DockerfileBuild = {
+      type: 'dockerfile',
+      context: 'examples/monorepo',
+      dockerfile: 'examples/monorepo/apps/backend/Dockerfile',
+      inputs: ['apps/backend/**']
+    }
+
+    process.chdir(root)
+    try {
+      await expect(docker.sourceKey('backend', build, {})).resolves.toMatch(/^[a-f0-9]{64}$/)
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+
+  it('uses BuildKit registry cache flags when DockerfileBuild.cache opts in', async () => {
+    const calls: Array<{ command: string; args: string[] }> = []
+    const docker = new Docker({
+      runner: {
+        run: async (command, args) => {
+          calls.push({ command, args })
+          return ''
+        }
+      },
+      logger: silentLogger
+    })
+
+    await docker.build(
+      'ghcr.io/acme/api:source-feedface',
+      {
+        type: 'dockerfile',
+        context: '.',
+        dockerfile: 'Dockerfile',
+        cache: { type: 'registry', mode: 'max' }
+      },
+      {}
+    )
+
+    expect(calls).toEqual([
+      {
+        command: 'docker',
+        args: expect.arrayContaining([
+          'buildx',
+          'build',
+          '--cache-from',
+          'type=registry,ref=ghcr.io/acme/api:cache',
+          '--cache-to',
+          'type=registry,ref=ghcr.io/acme/api:cache,mode=max',
+          '--load'
+        ])
+      }
+    ])
+  })
+})
+
+describe('digest image overrides', () => {
+  it('overrides planned app images with immutable digest refs', async () => {
+    const docker = new RecordingDocker()
+    const tsops = makeTsOps(docker)
+
+    const plan = await tsops.plan({
+      namespace: 'prod',
+      imageOverrides: { api: digestRef }
+    })
+
+    expect(plan.entries).toMatchObject([{ app: 'api', image: digestRef }])
+  })
+
+  it('rejects unknown or mutable image overrides', async () => {
+    const docker = new RecordingDocker()
+    const tsops = makeTsOps(docker)
+
+    await expect(
+      tsops.plan({
+        namespace: 'prod',
+        imageOverrides: { missing: digestRef }
+      })
+    ).rejects.toThrow('Unknown image override app "missing"')
+
+    await expect(
+      tsops.plan({
+        namespace: 'prod',
+        imageOverrides: { api: 'ghcr.io/acme/api:mutable' }
+      })
+    ).rejects.toThrow('must be an immutable digest ref')
+  })
+})
+
+function makeTsOps(docker: DockerClient) {
+  const config = defineConfig({
+    project: 'demo',
+    namespaces: {
+      prod: { domain: 'example.com' }
+    },
+    clusters: {
+      prod: {
+        apiServer: 'https://example.invalid',
+        context: 'prod',
+        namespaces: ['prod']
+      }
+    },
+    images: {
+      registry: 'ghcr.io/acme',
+      tagStrategy: 'git-sha'
+    },
+    apps: {
+      api: {
+        build: {
+          type: 'dockerfile',
+          context: '.',
+          dockerfile: 'Dockerfile',
+          inputs: ['apps/api/**', 'packages/shared/**']
+        },
+        ports: [{ name: 'http', port: 80, targetPort: 3000 }]
+      }
+    }
+  })
+
+  return new TsOps(config, {
+    docker,
+    kubectl: noopKubectl,
+    env: new NullEnvironmentProvider()
+  })
+}
+
+class RecordingDocker implements DockerClient {
+  sourceKeyCalls: Array<{ app: string; inputs?: readonly string[] }> = []
+  imageExistsCalls: string[] = []
+  buildCalls: string[] = []
+  pushCalls: string[] = []
+
+  constructor(
+    private readonly options: {
+      sourceKey?: string
+      existingImages?: Set<string>
+      digests?: Map<string, string>
+    } = {}
+  ) {}
+
+  async login() {}
+
+  async sourceKey(appName: string, build: DockerfileBuild) {
+    this.sourceKeyCalls.push({ app: appName, inputs: build.inputs })
+    return this.options.sourceKey ?? 'source'
+  }
+
+  async imageExists(imageRef: string) {
+    this.imageExistsCalls.push(imageRef)
+    return this.options.existingImages?.has(imageRef) ?? false
+  }
+
+  async resolveDigest(imageRef: string) {
+    return this.options.digests?.get(imageRef) ?? null
+  }
+
+  async build(imageRef: string) {
+    this.buildCalls.push(imageRef)
+  }
+
+  async push(imageRef: string) {
+    this.pushCalls.push(imageRef)
+  }
+}
+
+const noopKubectl = {
+  apply: async () => '',
+  applyBatch: async () => [],
+  validate: async () => true,
+  diff: async () => null,
+  get: async () => null,
+  getSecretData: async () => null,
+  listManagedResources: async () => [],
+  delete: async () => '',
+  waitForJob: async () => {}
+} as any
+
+const silentLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {}
+}

--- a/tests/build-source-key.test.ts
+++ b/tests/build-source-key.test.ts
@@ -1,16 +1,21 @@
 import {
   NullEnvironmentProvider,
   TsOps,
+  createConfigResolver,
   defineConfig,
   type DockerClient,
   type DockerfileBuild
 } from '@tsops/core'
+import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { Docker } from '@tsops/node'
 import { describe, expect, it } from 'vitest'
 
+const require = createRequire(import.meta.url)
+const nodePackage = require('../packages/node/package.json') as { version: string }
 const digest = `sha256:${'a'.repeat(64)}`
 const digestRef = `ghcr.io/acme/api@${digest}`
 
@@ -139,6 +144,66 @@ describe('Node Docker source-key computation', () => {
     expect(afterIncludedChange).not.toBe(first)
   })
 
+  it('includes .dockerignore content in the source key', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'tsops-dockerignore-key-'))
+    await writeFile(join(root, 'Dockerfile'), 'FROM scratch\n')
+    await writeFile(join(root, '.dockerignore'), 'ignored.txt\n')
+    await writeFile(join(root, 'ignored.txt'), 'ignored v1\n')
+    await writeFile(join(root, 'app.ts'), 'console.log("v1")\n')
+
+    const docker = new Docker({
+      runner: { run: async () => '' },
+      logger: silentLogger,
+      dryRun: true
+    })
+    const build: DockerfileBuild = {
+      type: 'dockerfile',
+      context: root,
+      dockerfile: join(root, 'Dockerfile'),
+      inputs: ['app.ts']
+    }
+
+    const first = await docker.sourceKey('api', build, {})
+    await writeFile(
+      join(root, '.dockerignore'),
+      '# same matcher, different file content\nignored.txt\n'
+    )
+    const afterDockerIgnoreChange = await docker.sourceKey('api', build, {})
+
+    expect(afterDockerIgnoreChange).not.toBe(first)
+  })
+
+  it('includes the Node adapter package version in custom source keys', async () => {
+    const docker = new Docker({
+      runner: { run: async () => '' },
+      logger: silentLogger,
+      dryRun: true
+    })
+
+    const actual = await docker.sourceKey(
+      'api',
+      {
+        type: 'dockerfile',
+        context: '.',
+        dockerfile: 'Dockerfile',
+        sourceKey: 'custom-key'
+      },
+      {}
+    )
+    const expected = createHash('sha256')
+      .update('tsops-source-key-v1\0')
+      .update('api')
+      .update('\0')
+      .update('@tsops/node\0')
+      .update(nodePackage.version)
+      .update('\0')
+      .update('custom\0')
+      .update('custom-key')
+      .digest('hex')
+
+    expect(actual).toBe(expected)
+  })
+
   it('resolves a repo-relative Dockerfile path under the build context', async () => {
     const root = await mkdtemp(join(tmpdir(), 'tsops-repo-key-'))
     const previousCwd = process.cwd()
@@ -236,6 +301,56 @@ describe('digest image overrides', () => {
         imageOverrides: { api: 'ghcr.io/acme/api:mutable' }
       })
     ).rejects.toThrow('must be an immutable digest ref')
+  })
+})
+
+describe('source-key input changed-file selection', () => {
+  it('uses build.inputs instead of the widened Docker context when selecting affected apps', () => {
+    const config = defineConfig({
+      project: 'demo',
+      namespaces: {
+        prod: { domain: 'example.com' }
+      },
+      clusters: {
+        prod: {
+          apiServer: 'https://example.invalid',
+          context: 'prod',
+          namespaces: ['prod']
+        }
+      },
+      images: {
+        registry: 'ghcr.io/acme',
+        tagStrategy: 'git-sha'
+      },
+      apps: {
+        backend: {
+          build: {
+            type: 'dockerfile',
+            context: 'examples/monorepo',
+            dockerfile: 'examples/monorepo/apps/backend/Dockerfile',
+            inputs: ['apps/backend/**', 'package.json', 'pnpm-lock.yaml']
+          }
+        },
+        frontend: {
+          build: {
+            type: 'dockerfile',
+            context: 'examples/monorepo',
+            dockerfile: 'examples/monorepo/apps/frontend/Dockerfile',
+            inputs: ['apps/frontend/**', 'package.json', 'pnpm-lock.yaml']
+          }
+        }
+      }
+    })
+    const resolver = createConfigResolver(config)
+
+    expect(
+      resolver.apps
+        .selectByChangedFiles(['examples/monorepo/apps/backend/src/index.ts'])
+        .map(([name]) => name)
+    ).toEqual(['backend'])
+    expect(
+      resolver.apps.selectByChangedFiles(['examples/monorepo/pnpm-lock.yaml']).map(([name]) => name)
+    ).toEqual(['backend', 'frontend'])
   })
 })
 

--- a/tests/dockerfile-build.test.ts
+++ b/tests/dockerfile-build.test.ts
@@ -24,6 +24,24 @@ describe('defineDockerfileBuild', () => {
     expect(build).toMatchObject({ target: 'production', platform: 'linux/arm64', context: '.' })
   })
 
+  it('carries source-key inputs and registry cache defaults into each build', () => {
+    const dockerfile = defineDockerfileBuild({
+      context: '.',
+      inputs: ['apps/api/**', 'packages/shared/**'],
+      sourceKey: { mode: 'inputs', inputs: ['apps/api/**'] },
+      cache: { type: 'registry', ref: 'ghcr.io/acme/api:cache', mode: 'max' }
+    })
+
+    expect(dockerfile('Dockerfile')).toMatchObject({
+      type: 'dockerfile',
+      context: '.',
+      dockerfile: 'Dockerfile',
+      inputs: ['apps/api/**', 'packages/shared/**'],
+      sourceKey: { mode: 'inputs', inputs: ['apps/api/**'] },
+      cache: { type: 'registry', ref: 'ghcr.io/acme/api:cache', mode: 'max' }
+    })
+  })
+
   it('shallow-merges env and args across defaults and overrides', () => {
     const dockerfile = defineDockerfileBuild({
       env: { A: '1', B: '2' },

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@tsops/core": "workspace:*",
+    "@tsops/node": "workspace:*",
     "tsops": "workspace:*"
   },
   "devDependencies": {


### PR DESCRIPTION
Refs #63

## Summary
- add Dockerfile build `inputs`, `sourceKey`, and registry cache config fields
- reuse `source-<hash>` image tags and return immutable digest refs when available
- add `tsops build --source-key` and `tsops deploy/up --image-digests` for CI preview handoff
- document the workflow and update the monorepo example

## Verification
- `pnpm build`
- `pnpm test`
- `pnpm docs:build`
- `pnpm tsops build -c examples/monorepo/tsops.config.ts --dry-run --source-key --app backend`

## Notes
- `pnpm lint` is currently blocked by pre-existing repo-wide Biome diagnostics, including explicit `any` generics in `packages/core/src/config/apps.ts` and non-null assertions in existing tests. I left that unrelated cleanup out of this feature branch.